### PR TITLE
Feat: load the system version requirements from the addon's meta.yaml(#395)

### DIFF
--- a/hack/addons/syn_addon_package.go
+++ b/hack/addons/syn_addon_package.go
@@ -41,6 +41,7 @@ type Metadata struct {
 	Tags          []string `json:"tags,omitempty"`
 	NeedNamespace []string `json:"needNamespace,omitempty"`
 	Invisible     bool     `json:"invisible"`
+	System        string   `json:"system"`
 }
 
 func main() {
@@ -105,7 +106,7 @@ func main() {
 			entry := repo.ChartVersions{}
 			entry = append(entry, &repo.ChartVersion{Metadata: &chart.Metadata{Name: info.Name(),
 				Version: m.Version, Icon: m.Icon, Keywords: m.Tags, Description: m.Description,
-				Home: m.URL}, Created: time.Now(), URLs: []string{repoURL + "/" + info.Name() + "-" + m.Version + ".tgz"}})
+				Home: m.URL, Annotations: map[string]string{"system": m.System}}, Created: time.Now(), URLs: []string{repoURL + "/" + info.Name() + "-" + m.Version + ".tgz"}})
 			entries[info.Name()] = entry
 
 			err = helmSave(dir, info.Name(), info.Name(), m.Version)

--- a/hack/addons/syn_addon_package.go
+++ b/hack/addons/syn_addon_package.go
@@ -33,15 +33,20 @@ import (
 )
 
 type Metadata struct {
-	Name          string   `json:"name" validate:"required"`
-	Version       string   `json:"version"`
-	Description   string   `json:"description"`
-	Icon          string   `json:"icon"`
-	URL           string   `json:"url,omitempty"`
-	Tags          []string `json:"tags,omitempty"`
-	NeedNamespace []string `json:"needNamespace,omitempty"`
-	Invisible     bool     `json:"invisible"`
-	System        string   `json:"system"`
+	Name          string              `json:"name" validate:"required"`
+	Version       string              `json:"version"`
+	Description   string              `json:"description"`
+	Icon          string              `json:"icon"`
+	URL           string              `json:"url,omitempty"`
+	Tags          []string            `json:"tags,omitempty"`
+	NeedNamespace []string            `json:"needNamespace,omitempty"`
+	Invisible     bool                `json:"invisible"`
+	System        *SystemRequirements `json:"system"`
+}
+
+type SystemRequirements struct {
+	Vela       string `json:"vela"`
+	Kubernetes string `json:"kubernetes"`
 }
 
 func main() {
@@ -106,7 +111,7 @@ func main() {
 			entry := repo.ChartVersions{}
 			entry = append(entry, &repo.ChartVersion{Metadata: &chart.Metadata{Name: info.Name(),
 				Version: m.Version, Icon: m.Icon, Keywords: m.Tags, Description: m.Description,
-				Home: m.URL, Annotations: map[string]string{"system": m.System}}, Created: time.Now(), URLs: []string{repoURL + "/" + info.Name() + "-" + m.Version + ".tgz"}})
+				Home: m.URL, Annotations: map[string]string{"system.vela": m.System.Vela, "system.kubernetes": m.System.Kubernetes}}, Created: time.Now(), URLs: []string{repoURL + "/" + info.Name() + "-" + m.Version + ".tgz"}})
 			entries[info.Name()] = entry
 
 			err = helmSave(dir, info.Name(), info.Name(), m.Version)

--- a/hack/addons/syn_addon_package.go
+++ b/hack/addons/syn_addon_package.go
@@ -109,9 +109,20 @@ func main() {
 				return
 			}
 			entry := repo.ChartVersions{}
-			entry = append(entry, &repo.ChartVersion{Metadata: &chart.Metadata{Name: info.Name(),
+			chartVersion := &repo.ChartVersion{Metadata: &chart.Metadata{Name: info.Name(),
 				Version: m.Version, Icon: m.Icon, Keywords: m.Tags, Description: m.Description,
-				Home: m.URL, Annotations: map[string]string{"system.vela": m.System.Vela, "system.kubernetes": m.System.Kubernetes}}, Created: time.Now(), URLs: []string{repoURL + "/" + info.Name() + "-" + m.Version + ".tgz"}})
+				Home: m.URL, Annotations: map[string]string{}}, Created: time.Now(), URLs: []string{repoURL + "/" + info.Name() + "-" + m.Version + ".tgz"}}
+
+			if m.System != nil {
+				if len(m.System.Kubernetes) != 0 {
+					chartVersion.Metadata.Annotations["system.kubernetes"] = m.System.Kubernetes
+				}
+				if len(m.System.Vela) != 0 {
+					chartVersion.Metadata.Annotations["system.vela"] = m.System.Vela
+				}
+			}
+
+			entry = append(entry, chartVersion)
 			entries[info.Name()] = entry
 
 			err = helmSave(dir, info.Name(), info.Name(), m.Version)


### PR DESCRIPTION
load the system version requirements from the addon's meta.yaml, and then write this value as a value to ChartVersions.Metadata.Annotations, the corresponding key is "system".


Signed-off-by: HanMengnan <1448189829@qq.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->


hack/addons/syn_addon_package.go

Fixes #395

A `System` field is added to the metadata structure in `hack/addons/syn_ addon_ package.go` to record the system version requirements.

To adapt this feature, we need to add a `system` field to addon's `meta.yaml` file.
```yaml
name: example
version: 1.0.1
description: Extended workload to do continuous and progressive delivery
icon: https://raw.githubusercontent.com/fluxcd/flux/master/docs/_files/weave-flux.png
url: https://fluxcd.io
system:
  vela: ">=v1.4.0-beta.2"
  kubernetes: ">=1.20.0"
```

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->

I have:

- [ ] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](../examples).
- [ ] New addon should be put in [experimental](../experimental/addons).
- [ ] Update addon should modify the `version` in `metadata.yaml` to generate a new version.
- [x] Any changes about [verified](../addons) addons should be tested with CI [script](../test/e2e-test/hack/addon-vela-test.sh).
