### PR TITLE
[Addon] CI support multi version of one addon

### DIFF
--- a/hack/addons/syn_addon_package.go
+++ b/hack/addons/syn_addon_package.go
@@ -109,9 +109,9 @@ func main() {
 				return
 			}
 			entry := repo.ChartVersions{}
-			chartVersion := &repo.ChartVersion{Metadata: &chart.Metadata{Name: info.Name(),
+			chartVersion := &repo.ChartVersion{Metadata: &chart.Metadata{Name: m.Name,
 				Version: m.Version, Icon: m.Icon, Keywords: m.Tags, Description: m.Description,
-				Home: m.URL, Annotations: map[string]string{}}, Created: time.Now(), URLs: []string{repoURL + "/" + info.Name() + "-" + m.Version + ".tgz"}}
+				Home: m.URL, Annotations: map[string]string{}}, Created: time.Now(), URLs: []string{repoURL + "/" + m.Name + "-" + m.Version + ".tgz"}}
 
 			if m.System != nil {
 				if len(m.System.Kubernetes) != 0 {
@@ -123,9 +123,9 @@ func main() {
 			}
 
 			entry = append(entry, chartVersion)
-			entries[info.Name()] = entry
+			entries[m.Name] = entry
 
-			err = helmSave(dir, info.Name(), info.Name(), m.Version)
+			err = helmSave(dir, m.Name, info.Name(), m.Version)
 			if err != nil {
 				fmt.Println(err)
 			}
@@ -147,7 +147,7 @@ func main() {
 }
 
 func helmSave(dir, name, addonDir, version string) error {
-	filename := fmt.Sprintf("%s%s-%s.tgz", dir, name, version)
+	filename := fmt.Sprintf("%s-%s.tgz", name, version)
 	var outInfo bytes.Buffer
 	cmd := exec.Command("tar", "zcf", filename, dir+addonDir+"/")
 	cmd.Stdout = &outInfo


### PR DESCRIPTION
addons dir support two versions of one same addon, eg: velaux and velaux-1.4

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](../examples).
- [ ] New addon should be put in [experimental](../experimental/addons).
- [ ] Update addon should modify the `version` in `metadata.yaml` to generate a new version.
- [x] Any changes about [verified](../addons) addons should be tested with CI [script](../test/e2e-test/hack/addon-vela-test.sh).
