### PR TITLE
[Addon] Refactor: refactor chartmuseum addon with vela native components

### DIFF
--- a/addons/chartmuseum/metadata.yaml
+++ b/addons/chartmuseum/metadata.yaml
@@ -1,5 +1,5 @@
 name: chartmuseum
-version: 3.8.1
+version: 4.0.0-beta
 description: ChartMuseum is an open-source and easy to deploy Helm Chart Repository server.
 icon: https://raw.githubusercontent.com/helm/chartmuseum/main/logo2.png
 url: https://chartmuseum.com

--- a/addons/chartmuseum/metadata.yaml
+++ b/addons/chartmuseum/metadata.yaml
@@ -1,5 +1,5 @@
 name: chartmuseum
-version: 4.0.0-beta
+version: 4.0.0
 description: ChartMuseum is an open-source and easy to deploy Helm Chart Repository server.
 icon: https://raw.githubusercontent.com/helm/chartmuseum/main/logo2.png
 url: https://chartmuseum.com

--- a/addons/chartmuseum/metadata.yaml
+++ b/addons/chartmuseum/metadata.yaml
@@ -1,14 +1,11 @@
 name: chartmuseum
-version: 3.8.0
+version: 3.8.1
 description: ChartMuseum is an open-source and easy to deploy Helm Chart Repository server.
 icon: https://raw.githubusercontent.com/helm/chartmuseum/main/logo2.png
 url: https://chartmuseum.com
 invisible: false
-dependencies:
-- name: fluxcd
 tags:
 - helm
 - registry
 - helm_chart
 - chartmuseum
-

--- a/addons/chartmuseum/readme.md
+++ b/addons/chartmuseum/readme.md
@@ -33,13 +33,21 @@ basicAuth: {
 
 ### Using with local filesystem storage
 
-By default ChartMuseum uses local filesystem storage.
-But on pod recreation it will lose all charts, to prevent that enable persistent storage.
+By default ChartMuseum uses local filesystem storage. But on pod recreation it will lose all charts, to prevent that, enable persistent storage. This will store your data to a automatically created PV.
 
 ```json5
 enablePersistence: true
-persistentSize:    "8Gi"
 ```
+
+> WARNING: even if you enabled persistent storage, when you disable the addon, data will still be deleted. Because the PVC will be deleted as well. 
+
+You should consider using a existing PVC by specifying `pvcName`.
+
+```json5
+enablePersistence: true
+pvcName: "mypvc"
+```
+
 
 ### Using with Alibaba Cloud OSS Storage
 

--- a/addons/chartmuseum/readme.md
+++ b/addons/chartmuseum/readme.md
@@ -33,10 +33,12 @@ basicAuth: {
 
 ### Using with local filesystem storage
 
-By default ChartMuseum uses local filesystem storage. But on pod recreation it will lose all charts, to prevent that, enable persistent storage. This will store your data to a automatically created PV.
+By default ChartMuseum uses local filesystem storage. But on pod recreation it will lose all charts, to prevent that, enable persistent storage. This will store your data to a automatically created PVC.
 
 ```json5
-enablePersistence: true
+persistence: {
+	enabled: true
+}
 ```
 
 > WARNING: even if you enabled persistent storage, when you disable the addon, data will still be deleted. Because the PVC will be deleted as well. 
@@ -44,8 +46,10 @@ enablePersistence: true
 You should consider using a existing PVC by specifying `pvcName`.
 
 ```json5
-enablePersistence: true
-pvcName: "mypvc"
+persistence: {
+	enabled: true
+	pvcName: "mypvc"
+}
 ```
 
 ### Using with Alibaba Cloud OSS Storage
@@ -105,8 +109,8 @@ storage: "google"
 google: {
 	// +usage=GCS bucket to store charts for google storage backend, e.g. my-gcs-bucket
 	bucket: "my-gcs-bucket"
-	// +usage=GCP service account json file
-	googleCredentialsJSON: "json"
+	// +usage=GCP service account json string
+	googleCredentialsJSON: "jsonstring"
 }
 ```
 

--- a/addons/chartmuseum/readme.md
+++ b/addons/chartmuseum/readme.md
@@ -48,7 +48,6 @@ enablePersistence: true
 pvcName: "mypvc"
 ```
 
-
 ### Using with Alibaba Cloud OSS Storage
 
 Make sure your environment is properly setup to access `my-oss-bucket`.

--- a/addons/chartmuseum/resources/chartmuseum.cue
+++ b/addons/chartmuseum/resources/chartmuseum.cue
@@ -54,21 +54,21 @@ import (
 		enabled: parameter.storage == "local" || parameter.google != _|_
 		type:    "storage"
 		properties: {
-			if !parameter.enablePersistence {
+			if !parameter.persistence.enabled {
 				emptyDir: [{
 					name:      "chartmuseum-local-storage"
 					mountPath: "/storage"
 				}]
 			}
-			if parameter.enablePersistence {
+			if parameter.persistence.enabled {
 				pvc: [{
-                    if parameter.pvcName != _|_ {
-                        name: parameter.pvcName
-                        mountOnly: true
-                    }
-                    if parameter.pvcName == _|_ {
-                        name: "chartmuseum-local-storage"
-                    }
+					if parameter.persistence.pvcName != _|_ {
+						name:      parameter.pvcName
+						mountOnly: true
+					}
+					if parameter.persistence.pvcName == _|_ {
+						name: "chartmuseum-local-storage"
+					}
 					mountPath: "/storage"
 				}]
 			}

--- a/addons/chartmuseum/resources/chartmuseum.cue
+++ b/addons/chartmuseum/resources/chartmuseum.cue
@@ -1,124 +1,146 @@
-output: {
-	type: "helm"
-	properties: {
-		url:      "https://chartmuseum.github.io/charts"
-		repoType: "helm"
-		chart:    "chartmuseum"
-		version:  context.metadata.version
-		values: {
-			env: {
-				open: {
-					STORAGE: parameter.storage
+import (
+	"strconv"
+)
 
-					if parameter.storage == "alibaba" && parameter.alibaba != _|_ {
-						STORAGE_ALIBABA_BUCKET:   parameter.alibaba.bucket
-						STORAGE_ALIBABA_ENDPOINT: parameter.alibaba.endpoint
+#envs: {
+	STORAGE:               parameter.storage
+	STORAGE_LOCAL_ROOTDIR: "/storage"
+	PORT:                  strconv.FormatInt(parameter.externalPort, 10)
+	if parameter.alibaba != _|_ {
+		STORAGE_ALIBABA_BUCKET:          parameter.alibaba.bucket
+		STORAGE_ALIBABA_PREFIX:          parameter.alibaba.prefix
+		STORAGE_ALIBABA_ENDPOINT:        parameter.alibaba.endpoint
+		STORAGE_ALIBABA_SSE:             parameter.alibaba.sse
+		ALIBABA_CLOUD_ACCESS_KEY_ID:     parameter.alibaba.accessKeyID
+		ALIBABA_CLOUD_ACCESS_KEY_SECRET: parameter.alibaba.accessKeySecret
+	}
+	if parameter.amazon != _|_ {
+		STORAGE_AMAZON_BUCKET:   parameter.amazon.bucket
+		STORAGE_AMAZON_PREFIX:   parameter.amazon.prefix
+		STORAGE_AMAZON_REGION:   parameter.amazon.region
+		STORAGE_AMAZON_ENDPOINT: parameter.amazon.endpoint
+		STORAGE_AMAZON_SSE:      parameter.amazon.sse
+		AWS_ACCESS_KEY_ID:       parameter.amazon.accessKeyID
+		AWS_SECRET_ACCESS_KEY:   parameter.amazon.accessKeySecret
+	}
+	if parameter.google != _|_ {
+		STORAGE_GOOGLE_BUCKET:          parameter.google.bucket
+		STORAGE_GOOGLE_PREFIX:          parameter.google.prefix
+		GOOGLE_APPLICATION_CREDENTIALS: "/etc/secrets/google/credentials.json"
+	}
+	if parameter.microsoft != _|_ {
+		STORAGE_MICROSOFT_CONTAINER: parameter.microsoft.container
+		STORAGE_MICROSOFT_PREFIX:    parameter.microsoft.prefix
+		AZURE_STORAGE_ACCOUNT:       parameter.microsoft.account
+		AZURE_STORAGE_ACCESS_KEY:    parameter.microsoft.accessKey
+	}
+	DEBUG:              strconv.FormatBool(parameter.debug)
+	DISABLE_API:        strconv.FormatBool(parameter.disableAPI)
+	ALLOW_OVERWRITE:    strconv.FormatBool(parameter.allowOverwrite)
+	AUTH_ANONYMOUS_GET: strconv.FormatBool(parameter.authAnonymousGet)
+	if parameter.basicAuth != _|_ {
+		BASIC_AUTH_USER: parameter.basicAuth.username
+		BASIC_AUTH_PASS: parameter.basicAuth.password
+	}
+}
 
-						if parameter.alibaba.prefix != _|_ {
-							STORAGE_ALIBABA_PREFIX: parameter.alibaba.prefix
-						}
-
-						if parameter.alibaba.sse != _|_ {
-							STORAGE_ALIBABA_SSE: parameter.alibaba.sse
-						}
-					}
-
-					if parameter.storage == "google" && parameter.google != _|_ {
-						STORAGE_GOOGLE_BUCKET: parameter.google.bucket
-
-						if parameter.google.prefix != _|_ {
-							STORAGE_GOOGLE_PREFIX: parameter.google.prefix
-						}
-					}
-
-					if parameter.storage == "microsoft" && parameter.microsoft != _|_ {
-						STORAGE_MICROSOFT_CONTAINER: parameter.microsoft.container
-
-						if parameter.microsoft.prefix != _|_ {
-							STORAGE_MICROSOFT_PREFIX: parameter.microsoft.prefix
-						}
-					}
-
-					DEBUG:              parameter.debug
-					DISABLE_API:        parameter.disableAPI
-					ALLOW_OVERWRITE:    parameter.allowOverwrite
-					AUTH_ANONYMOUS_GET: parameter.authAnonymousGet
-				}
-
-				secret: {
-					if parameter.basicAuth != _|_ && parameter.basicAuth.username != _|_ && parameter.basicAuth.password != _|_ {
-						BASIC_AUTH_USER: parameter.basicAuth.username
-						BASIC_AUTH_PASS: parameter.basicAuth.password
-					}
-
-					if parameter.storage != _|_ {
-						if parameter.storage == "alibaba" && parameter.alibaba.accessKeyID != _|_ && parameter.alibaba.accessKeySecret != _|_ {
-							ALIBABA_CLOUD_ACCESS_KEY_ID:     parameter.alibaba.accessKeyID
-							ALIBABA_CLOUD_ACCESS_KEY_SECRET: parameter.alibaba.accessKeySecret
-						}
-
-						if parameter.storage == "amazon" && parameter.amazon.accessKeyID != _|_ && parameter.amazon.accessKeySecret != _|_ {
-							AWS_ACCESS_KEY_ID:     parameter.amazon.accessKeyID
-							AWS_SECRET_ACCESS_KEY: parameter.amazon.accessKeySecret
-						}
-
-						if parameter.storage == "google" && parameter.google.googleCredentialsJSON != _|_ {
-							GOOGLE_CREDENTIALS_JSON: parameter.google.googleCredentialsJSON
-						}
-
-						if parameter.storage == "microsoft" && parameter.microsoft.account != _|_ && parameter.microsoft.accessKey != _|_ {
-							AZURE_STORAGE_ACCOUNT:    parameter.microsoft.account
-							AZURE_STORAGE_ACCESS_KEY: parameter.microsoft.accessKey
-						}
-					}
-				}
+#traitsAll: [
+	{
+		// NOTE: The `enabled` var is a workaround,
+		//       because we need some features (`multiple comprehensions per list` from CUE v0.3.0),
+		//       which will make this code much clearer,
+		//       but we only have v0.2.2
+		// TODO(charlie0129): refactor this using `multiple comprehensions per list` feature from v0.3.0
+		enabled: parameter.storage == "local" || parameter.google != _|_
+		type:    "storage"
+		properties: {
+			if !parameter.enablePersistence {
+				emptyDir: [{
+					name:      "chartmuseum-local-storage"
+					mountPath: "/storage"
+				}]
 			}
-
-			service: {
-				type: parameter.serviceType
-
-				if parameter.serviceType == "LoadBalancer" && parameter.loadBalancerIP != _|_ {
-					loadBalancerIP: parameter.loadBalancerIP
-				}
-
-				if parameter.externalPort != _|_ {
-					externalPort: parameter.externalPort
-				}
-
-				if parameter.nodePort != _|_ {
-					nodePort: parameter.nodePort
-				}
+			if parameter.enablePersistence {
+				pvc: [{
+                    if parameter.pvcName != _|_ {
+                        name: parameter.pvcName
+                        mountOnly: true
+                    }
+                    if parameter.pvcName == _|_ {
+                        name: "chartmuseum-local-storage"
+                    }
+					mountPath: "/storage"
+				}]
 			}
-
-			serviceMonitor: {
-				enabled: parameter.enableServiceMonitor
-			}
-
-			persistence: {
-				enabled: parameter.enablePersistence
-				size:    parameter.persistentSize
-			}
-
-			ingress: {
-				enabled: parameter.enableIngress
-				annotations: {
-					for k, v in parameter.ingressAnnotations {
-						"\(k)": v
-					}
-				}
-				hosts: [
-					if parameter.ingressHosts != _|_ {
-						for h in parameter.ingressHosts {
-							name: h.name
-							path: h.path
-							tls:  h.tls
-							if h.tlsSecret != _|_ {
-								tlsSecret: h.tlsSecret
-							}
-						}
-					}
-				]
+			if parameter.google != _|_ {
+				secret: [{
+					name:      "chartmuseum-gcs-credential"
+					mountPath: "/etc/secrets/google"
+					items: [{
+						key:  "json"
+						path: "credentials.json"
+					}]
+				}]
 			}
 		}
+	},
+	{
+		enabled: parameter.ingressHost != _|_
+		type:    "gateway"
+		properties: {
+			domain: parameter.ingressHost.name
+			http: {
+				"\(parameter.ingressHost.path)": parameter.externalPort
+			}
+			if parameter.ingressHost.tls {
+				secretName: parameter.ingressHost.tlsSecret
+			}
+		}
+	},
+	{
+		enabled: true
+		type:    "env"
+		properties: {
+			env: {
+				for k, v in #envs if v != _|_ if v != "" {
+					"\(k)": v
+				}
+			}
+		}
+	},
+]
+
+output: {
+	type: "webservice"
+	properties: {
+		image:           parameter.image
+		imagePullPolicy: "IfNotPresent"
+		ports: [
+			{
+				name:   "http"
+				port:   parameter.externalPort
+				expose: true
+			},
+		]
+		exposeType: parameter.serviceType
+		livenessProbe: {
+			httpGet: {
+				path: "/health"
+				port: parameter.externalPort
+			}
+			initialDelaySeconds: 5
+		}
+		readinessProbe: {
+			httpGet: {
+				path: "/health"
+				port: parameter.externalPort
+			}
+			initialDelaySeconds: 5
+		}
 	}
+	traits: [
+		for t in #traitsAll if t.enabled {
+			t
+		},
+	]
 }

--- a/addons/chartmuseum/resources/gcs-credential.cue
+++ b/addons/chartmuseum/resources/gcs-credential.cue
@@ -1,0 +1,29 @@
+import (
+	"encoding/base64"
+)
+
+// if parameter.google != _|_ {
+//   -> This if-statement requires CLI v1.5 or later. (#4347)
+//   -> And it is commented-out because v1.5 is not available yet.
+//   -> TODO(charlie0129): uncomment it once v1.5 is widely available.
+output: {
+	type: "k8s-objects"
+	properties: {
+		objects: [{
+			apiVersion: "v1"
+			kind:       "Secret"
+			metadata: {
+				name:      "chartmuseum-gcs-credential"
+				namespace: "vela-system"
+			}
+			type: "Opaque"
+			data: {
+				// Remove this if-statement, if the outer one is used.
+				if parameter.google != _|_ {
+					json: base64.Encode(null, parameter.google.googleCredentialsJSON)
+				}
+			}
+		}]
+	}
+}
+// }

--- a/addons/chartmuseum/resources/parameter.cue
+++ b/addons/chartmuseum/resources/parameter.cue
@@ -1,4 +1,6 @@
 parameter: {
+	// +usage=ChartMuseum image
+	image: *"ghcr.io/helm/chartmuseum:v0.15.0" | string
 	// +usage=Storage backend, can be one of: local(default), alibaba, amazon, google, microsoft
 	storage: *"local" | "alibaba" | "amazon" | "google" | "microsoft"
 	// +usage=Alibaba Cloud storage backend settings
@@ -21,7 +23,7 @@ parameter: {
 		// +usage=S3 bucket to store charts for amazon storage backend, e.g. my-s3-bucket
 		bucket: string
 		// +usage=Prefix to store charts for amazon storage backend
-		prefix?: *"string" | string
+		prefix?: string
 		// +usage=Region of s3 bucket to store charts, e.g. us-east-1
 		region: string
 		// +usage=Alternative s3 endpoint
@@ -39,7 +41,7 @@ parameter: {
 		bucket: string
 		// +usage=Prefix to store charts for google storage backend
 		prefix?: string
-		// +usage=GCP service account json file
+		// +usage=GCP service account json string
 		googleCredentialsJSON: string
 	}
 	// +usage=Microsoft Azure storage backend settings
@@ -70,26 +72,20 @@ parameter: {
 	}
 	// +usage=Service type
 	serviceType: *"ClusterIP" | "NodePort" | "LoadBalancer"
-	// +usage=Uses pre-assigned IP address from cloud provider, only valid when serviceType=LoadBalancer
-	loadBalancerIP?: int
-	externalPort?:   *8080 | int
-	nodePort?:       int
-	// +usage=Enable metrics at /metrics
-	enableServiceMonitor: *false | bool
-	// +usage=Persist ChartMuseum data
+	// +usage=Access ChartMuseum from this port
+	externalPort: *8080 | int
+	// +usage=Persist ChartMuseum data to PV. PVC will be created automatically. Specify a pvcName to prevent that.
 	enablePersistence: *false | bool
-	persistentSize:    *"8Gi" | =~"^([1-9][0-9]{0,63})(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)$"
-    // +usage=Enable Ingress for load balancer
-    enableIngress: *false | bool
-    ingressAnnotations: [string]: string | null
-    // +usage=Hosts for Ingress
-    ingressHosts?: [...{
-        // +usage=Domain name, e.g. cm.domain.com
-        name: string
-        path: *"/" | string
-        // +usage=Enable TLS on the ingress record
-        tls: *false | bool
-        // +usage=If TLS is set to true, you must declare what secret will store the key/certificate for TLS. Secrets must be added manually to the vela-system.
-        tlsSecret?: string
-    }]
+	// +usage=Use an existing PVC. If you specify this, PVC will NOT be created automatically.
+	pcvName?: string
+	// +usage=Hosts for Ingress
+	ingressHost?: {
+		// +usage=Domain name, e.g. cm.domain.com
+		name: string
+		path: *"/" | string
+		// +usage=Enable TLS on the ingress record
+		tls: *false | bool
+		// +usage=If TLS is set to true, you must declare what secret will store the key/certificate for TLS. Secrets must be added manually to the vela-system.
+		tlsSecret?: string
+	}
 }

--- a/addons/chartmuseum/resources/parameter.cue
+++ b/addons/chartmuseum/resources/parameter.cue
@@ -74,10 +74,16 @@ parameter: {
 	serviceType: *"ClusterIP" | "NodePort" | "LoadBalancer"
 	// +usage=Access ChartMuseum from this port
 	externalPort: *8080 | int
-	// +usage=Persist ChartMuseum data to PV. PVC will be created automatically. Specify a pvcName to prevent that.
-	enablePersistence: *false | bool
-	// +usage=Use an existing PVC. If you specify this, PVC will NOT be created automatically.
-	pcvName?: string
+	// +usage=Settings related to persisting data. You only need this if you are using local storage.
+	persistence: {
+		// +usage=Persist ChartMuseum data to PV. PVC will be created automatically. Specify a pvcName to prevent that.
+		enabled: *false | bool
+		// This is commented out because I haven't found a way to specify policies.
+		// Keep automatically created PVC even if addon is deleted.
+		// alwaysKeep: *false | bool
+		// +usage=Use an existing PVC. If you specify this, PVC will NOT be created automatically.
+		pvcName?: string
+	}
 	// +usage=Hosts for Ingress
 	ingressHost?: {
 		// +usage=Domain name, e.g. cm.domain.com

--- a/addons/chartmuseum/template.yaml
+++ b/addons/chartmuseum/template.yaml
@@ -4,4 +4,4 @@ metadata:
   name: chartmuseum
   namespace: vela-system
 spec:
-  components: null
+  components: []


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes

- Use vela built-in components. No dependencies required, which means we no longer need `fluxcd`. So users can easily install this in air-gapped environments.
- Add `image` parameter to make air-gapped installation possible.
- Support specifying existing PVC (in addition to auto-generated) to persist data.
- Delete some inappropriate parameters due to the usage of built-in traits.

### How has this code been tested?

Locally tested with some common parameters

### Checklist

<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->

A tutorial on air-gapped installation of addons is planned.

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [x] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](../examples).
- [ ] New addon should be put in [experimental](../experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.
- [ ] Any changes about [verified](../addons) addons should be tested with CI [script](../test/e2e-test/hack/addon-vela-test.sh).
