### PR TITLE
[Addon] add the azure-keyvault-csi addon

### DIFF
--- a/experimental/addons/azure-keyvault-csi/README.md
+++ b/experimental/addons/azure-keyvault-csi/README.md
@@ -1,0 +1,56 @@
+
+# Azure Keyvault CSI Trait
+
+Uses the [Azure Key Vault Provider for Secrets Store CSI Driver](https://github.com/Azure/secrets-store-csi-driver-provider-azure)
+to provide secrets/keys/certs from an Azure Keyvault to the component using
+a CSI inline volume mounted at `/mnt/secrets-store`.
+
+The Azure Key Vault Provider and Secrets Store CSI Driver must already be 
+installed in the cluster - see [installation instructions](https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/getting-started/installation/)
+
+## Use case example
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: myapp
+spec:
+  components:
+  - name: myapp
+    type: webservice
+    properties:
+      image: me/myapp:latest
+    traits:
+      - type: azure-keyvault-csi
+        properties:
+          keyvaultName:           #{KEY_VAULT_NAME}#
+          subscriptionId:         #{SUBSCRIPTION_ID}#
+          tenantId:               #{TENANT_ID}#
+          userAssignedIdentityID: #{USER_ASSIGNED_IDENTITY_ID}#
+          keys:
+          - name: my-secret            # get a secret value
+          - name: my-cert              # get a certificate
+            type: cert
+          - name: my-other-cert        # get a public key of a certificate
+            type: key
+```
+
+
+## Further reading
+
+### Secrets as mounted files
+
+For details about the access of secrets as mounted files see [Consuming Secret values from volumes](https://kubernetes.io/docs/concepts/configuration/secret/#consuming-secret-values-from-volumes).
+
+### Retrieving certificates
+
+For details on types when retrieving certificates, see
+[Getting Certificates and Keys using Azure Key Vault Provider](https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/configurations/getting-certs-and-keys/#how-to-obtain-the-certificate)
+
+### Dotnet core
+
+For the dotnet core builtin config provider that supports this, see [key-per-file-configuration provider](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-6.0#key-per-file-configuration-provider).
+
+For how to ensure that secrets mounted as file override `appsettings.json` values, see [Application configuration providers](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-6.0#application-configuration-providers)
+

--- a/experimental/addons/azure-keyvault-csi/definitions/azure-keyvault-csi.cue
+++ b/experimental/addons/azure-keyvault-csi/definitions/azure-keyvault-csi.cue
@@ -1,0 +1,87 @@
+// apply with "vela def apply azure-keyvault-csi.cue"
+
+import "strings"
+
+"azure-keyvault-csi": {
+    type: "trait"
+    annotations: {}
+    labels: {}
+    description: "Add filesystem-mounted values from Azure KeyVault, using Azure key vault provider for secrets store csi driver which must be installed separately, see https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/getting-started/installation/"
+    attributes: {
+        appliesToWorkloads: ["deployments.apps"]
+        podDisruptive: true
+    }
+}
+
+template: {
+    kvObjects: [
+        for v in parameter.keys {
+            "  objectName: " + v.name + "\n" + "  objectType: " + v.type
+        },
+    ]
+
+    kvObjectsString: "array:\n- |\n" + strings.Join(kvObjects,"\n- |\n")
+
+    patch: spec: template: spec: {
+        // +patchKey=name
+        volumes: [{
+          name: "secrets-store",
+          csi: {
+            driver: "secrets-store.csi.k8s.io",
+            readOnly: true,
+            volumeAttributes: {
+              secretProviderClass: context.name
+            }
+          }
+        },]
+        containers: [{
+          volumeMounts: [{
+            mountPath: "/mnt/secrets-store",
+            name: "secrets-store",
+            readOnly: true
+          },]
+        },]
+    }
+
+    outputs: {
+        "SecretProviderClass": {
+            apiVersion: "secrets-store.csi.x-k8s.io/v1"
+            kind: "SecretProviderClass"
+            metadata: {
+              name: context.name
+            }
+            spec: {
+              parameters: {
+                subscriptionId: parameter.subscriptionId,
+                tenantId: parameter.tenantId,
+                userAssignedIdentityID: parameter.userAssignedIdentityID,
+                keyvaultName: parameter.keyvaultName,
+                usePodIdentity: "false",
+                useVMManagedIdentity: "true",
+                objects: kvObjectsString
+              }
+              provider: "azure"
+           }
+        }
+    }
+
+    parameter: {
+      // +usage=What to use from the KeyVault.
+      keys: [...{
+        // +usage=Keyvault key
+        name: string
+        // +usage="secret" (default).  Or "key" or "cert" if key contains a certificate - see https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/configurations/getting-certs-and-keys/#how-to-obtain-the-certificate
+        type: *"secret" | "key" | "cert"
+      }]
+      // +usage=The Azure KeyVault to connect to
+      keyvaultName:           string
+      // +usage=The Azure subscriptionId for access to the KeyVault
+      subscriptionId:         string
+      // +usage=The Azure tenantId for access to the KeyVault
+      tenantId:               string
+      // +usage=The Azure ClientID of the Managed Identity for access to the KeyVault
+      userAssignedIdentityID: string
+
+    }
+
+}

--- a/experimental/addons/azure-keyvault-csi/metadata.yaml
+++ b/experimental/addons/azure-keyvault-csi/metadata.yaml
@@ -1,0 +1,14 @@
+name: azure-keyvault-csi
+version: 0.0.1
+system:
+  vela: ">=v1.4.0"
+description: Trait providing access to Azure Keyvault values via csi driver
+url: https://github.com/Azure/secrets-store-csi-driver-provider-azure
+
+tags:
+  - alpha
+  - azure
+  - keyvault
+  - secret
+  - csi
+

--- a/experimental/addons/azure-keyvault-csi/template.yaml
+++ b/experimental/addons/azure-keyvault-csi/template.yaml
@@ -1,0 +1,6 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: azure-keyvault-csi
+  namespace: vela-system
+spec:


### PR DESCRIPTION
### Description of your changes

Add an azure-keyvault-csi trait addon.

As discussed with @FogDong & @wonderflow .

### How has this code been tested?

Used in our own AKS cluster to add secrets from an azure KeyVault which can then be successfully viewed with:

```
kubectl exec -n vela-test myapp-pod-name -- cat /mnt/secrets-store/my-secret
```

### Checklist

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](../examples). 
    - `not updated docs as they are in main repo and this PR to experimental addon not yet accepted.  Example in README`
- [x] New addon should be put in [experimental](../experimental/addons).
- [ ] Update addon should modify the `version` in `metadata.yaml` to generate a new version. 
    - `no update, new addon, v0.0.1`
- [ ] Any changes about [verified](../addons) addons should be tested with CI [script](../test/e2e-test/hack/addon-vela-test.sh).
    - `experimental addon only`
