### PR TITLE
Feat: add prometheus-server

### DIFF
--- a/addons/prometheus-server/definitions/prometheus-scrape.cue
+++ b/addons/prometheus-server/definitions/prometheus-scrape.cue
@@ -1,0 +1,35 @@
+"prometheus-scrape": {
+	alias: ""
+	annotations: {}
+	attributes: podDisruptive: false
+	description: "Expose port and allow prometheus to scrape the service."
+	labels: "ui-hidden": "true"
+	type: "trait"
+}
+
+template: {
+	outputs: service: {
+		apiVersion: "v1"
+		kind:       "Service"
+		metadata: name: context.name
+		metadata: annotations: {
+			"prometheus.io/port":   "\(parameter.port)"
+			"prometheus.io/scrape": "true"
+			"prometheus.io/path":   parameter.path
+		}
+		spec: {
+			selector: "app.oam.dev/component": context.name
+			ports: [{
+				port:       parameter.port
+				targetPort: parameter.port
+			}]
+			type: "ClusterIP"
+		}
+	}
+	parameter: {
+		// +usage=Specify the port to be scraped
+		port: *8080 | int
+		// +usage=Specify the path to be scraped
+		path: *"/metrics" | string
+	}
+}

--- a/addons/prometheus-server/metadata.yaml
+++ b/addons/prometheus-server/metadata.yaml
@@ -1,0 +1,16 @@
+name: prometheus-server
+version: v0.1.0
+description: An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
+icon: https://artifacthub.io/image/0503add5-3fce-4b63-bbf3-b9f649512a86@1x
+url: https://prometheus.io/
+
+tags:
+ - Observability
+ - Kubernetes
+ - Prometheus
+ - Metrics
+
+invisible: false
+
+system:
+  vela: ">=v1.5.0-beta.4"

--- a/addons/prometheus-server/parameter.cue
+++ b/addons/prometheus-server/parameter.cue
@@ -1,0 +1,32 @@
+package main
+
+parameter: {
+
+	// global parameters
+
+	// +usage=The namespace of the prometheus-server to be installed
+	namespace: *"o11y-system" | string
+	// +usage=The name of the addon application
+	name: "addon-prometheus-server"
+	// +usage=The clusters to install
+	clusters?: [...string]
+
+	// prometheus-server parameters
+
+	// +usage=Specify the image of prometheus-server
+	image: *"quay.io/prometheus/prometheus:v2.34.0" | string
+	// +usage=Specify the imagePullPolicy of the image
+	imagePullPolicy: *"IfNotPresent" | "Never" | "Always"
+	// +usage=Specify the number of CPU units
+	cpu: *0.5 | number
+	// +usage=Specifies the attributes of the memory resource required for the container.
+	memory: *"1024Mi" | string
+	// +usage=Specify the service type for expose prometheus server. If empty, it will be not exposed.
+	serviceType: *"ClusterIP" | "NodePort" | "LoadBalancer" | ""
+	// +usage=Specify the storage size to use. If empty, emptyDir will be used. Otherwise pvc will be used.
+	storage: *"" | string
+	// +usage=If specified, the prometheus server will mount the config map as the additional config.
+	customConfig: *"" | string
+	// +usage=If specified, thanos sidecar will be attached and ports will be exposed
+	thanos: *false | bool
+}

--- a/addons/prometheus-server/readme.md
+++ b/addons/prometheus-server/readme.md
@@ -1,0 +1,31 @@
+# Prometheus Server
+
+[Prometheus](https://prometheus.io/), a [Cloud Native Computing Foundation](https://cncf.io/) project, is a systems and service monitoring system. It collects metrics from configured targets at given intervals, evaluates rule expressions, displays the results, and can trigger alerts if some condition is observed to be true.
+
+This addon installs the minimal core server of Prometheus into clusters.
+
+## Installation
+
+Install prometheus server to all clusters with recommend parameters.
+
+```shell
+vela addon enable prometheus-server thanos=true serviceType=LoadBalancer storage=1G
+```
+
+Install prometheus server with custom config in ConfigMap. (This needs the target ConfigMap exists in the namespace o11y-system in all clusters.)
+
+```shell
+vela addon enable prometheus-server customConfig=prometheus-custom-config
+```
+
+Install prometheus server with thanos sidecar and query. This will help you get the aggregated query interface across all clusters.
+
+```shell
+vela addon enable prometheus-server thanos=true serviceType=LoadBalancer
+```
+
+Install prometheus server with persistent storage.
+
+```shell
+vela addon enable prometheus-server storage=1G
+```

--- a/addons/prometheus-server/resources/prometheus-config.cue
+++ b/addons/prometheus-server/resources/prometheus-config.cue
@@ -1,0 +1,333 @@
+package main
+
+prometheusConfig: {
+	name: "prometheus-config"
+	type: "k8s-objects"
+	properties: objects: [{
+		apiVersion: "v1"
+		kind:       "ConfigMap"
+		metadata: name: "prometheus-server"
+		data: {
+			"allow-snippet-annotations": "false"
+			"alerting_rules.yml":        "{}"
+			"alerts":                    "{}"
+			"prometheus.yml": ##"""
+                global:
+                  evaluation_interval: 1m
+                  scrape_interval: 1m
+                  scrape_timeout: 10s
+                  external_labels:
+                    cluster: $CLUSTER
+                rule_files:
+                - /etc/config/recording_rules.yml
+                - /etc/config/alerting_rules.yml
+                - /etc/config/rules
+                - /etc/config/alerts
+                - /etc/custom/*.yml
+                scrape_configs:
+                - job_name: prometheus
+                  static_configs:
+                  - targets:
+                    - localhost:9090
+                - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                  job_name: kubernetes-apiservers
+                  kubernetes_sd_configs:
+                  - role: endpoints
+                  relabel_configs:
+                  - action: keep
+                    regex: default;kubernetes;https
+                    source_labels:
+                    - __meta_kubernetes_namespace
+                    - __meta_kubernetes_service_name
+                    - __meta_kubernetes_endpoint_port_name
+                  scheme: https
+                  tls_config:
+                    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                    insecure_skip_verify: true
+                - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                  job_name: kubernetes-nodes
+                  kubernetes_sd_configs:
+                  - role: node
+                  relabel_configs:
+                  - action: labelmap
+                    regex: __meta_kubernetes_node_label_(.+)
+                  - replacement: kubernetes.default.svc:443
+                    target_label: __address__
+                  - regex: (.+)
+                    replacement: /api/v1/nodes/$1/proxy/metrics
+                    source_labels:
+                    - __meta_kubernetes_node_name
+                    target_label: __metrics_path__
+                  scheme: https
+                  tls_config:
+                    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                    insecure_skip_verify: true
+                - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                  job_name: kubernetes-nodes-cadvisor
+                  kubernetes_sd_configs:
+                  - role: node
+                  relabel_configs:
+                  - action: labelmap
+                    regex: __meta_kubernetes_node_label_(.+)
+                  - replacement: kubernetes.default.svc:443
+                    target_label: __address__
+                  - regex: (.+)
+                    replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+                    source_labels:
+                    - __meta_kubernetes_node_name
+                    target_label: __metrics_path__
+                  scheme: https
+                  tls_config:
+                    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                    insecure_skip_verify: true
+                - honor_labels: true
+                  job_name: kubernetes-service-endpoints
+                  kubernetes_sd_configs:
+                  - role: endpoints
+                  relabel_configs:
+                  - action: keep
+                    regex: true
+                    source_labels:
+                    - __meta_kubernetes_service_annotation_prometheus_io_scrape
+                  - action: drop
+                    regex: true
+                    source_labels:
+                    - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+                  - action: replace
+                    regex: (https?)
+                    source_labels:
+                    - __meta_kubernetes_service_annotation_prometheus_io_scheme
+                    target_label: __scheme__
+                  - action: replace
+                    regex: (.+)
+                    source_labels:
+                    - __meta_kubernetes_service_annotation_prometheus_io_path
+                    target_label: __metrics_path__
+                  - action: replace
+                    regex: (.+?)(?::\d+)?;(\d+)
+                    replacement: $1:$2
+                    source_labels:
+                    - __address__
+                    - __meta_kubernetes_service_annotation_prometheus_io_port
+                    target_label: __address__
+                  - action: labelmap
+                    regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+                    replacement: __param_$1
+                  - action: labelmap
+                    regex: __meta_kubernetes_service_label_(.+)
+                  - action: replace
+                    source_labels:
+                    - __meta_kubernetes_namespace
+                    target_label: namespace
+                  - action: replace
+                    source_labels:
+                    - __meta_kubernetes_service_name
+                    target_label: service
+                  - action: replace
+                    source_labels:
+                    - __meta_kubernetes_pod_node_name
+                    target_label: node
+                - honor_labels: true
+                  job_name: kubernetes-service-endpoints-slow
+                  kubernetes_sd_configs:
+                  - role: endpoints
+                  relabel_configs:
+                  - action: keep
+                    regex: true
+                    source_labels:
+                    - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+                  - action: replace
+                    regex: (https?)
+                    source_labels:
+                    - __meta_kubernetes_service_annotation_prometheus_io_scheme
+                    target_label: __scheme__
+                  - action: replace
+                    regex: (.+)
+                    source_labels:
+                    - __meta_kubernetes_service_annotation_prometheus_io_path
+                    target_label: __metrics_path__
+                  - action: replace
+                    regex: (.+?)(?::\d+)?;(\d+)
+                    replacement: $1:$2
+                    source_labels:
+                    - __address__
+                    - __meta_kubernetes_service_annotation_prometheus_io_port
+                    target_label: __address__
+                  - action: labelmap
+                    regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+                    replacement: __param_$1
+                  - action: labelmap
+                    regex: __meta_kubernetes_service_label_(.+)
+                  - action: replace
+                    source_labels:
+                    - __meta_kubernetes_namespace
+                    target_label: namespace
+                  - action: replace
+                    source_labels:
+                    - __meta_kubernetes_service_name
+                    target_label: service
+                  - action: replace
+                    source_labels:
+                    - __meta_kubernetes_pod_node_name
+                    target_label: node
+                  scrape_interval: 5m
+                  scrape_timeout: 30s
+                - honor_labels: true
+                  job_name: prometheus-pushgateway
+                  kubernetes_sd_configs:
+                  - role: service
+                  relabel_configs:
+                  - action: keep
+                    regex: pushgateway
+                    source_labels:
+                    - __meta_kubernetes_service_annotation_prometheus_io_probe
+                - honor_labels: true
+                  job_name: kubernetes-services
+                  kubernetes_sd_configs:
+                  - role: service
+                  metrics_path: /probe
+                  params:
+                    module:
+                    - http_2xx
+                  relabel_configs:
+                  - action: keep
+                    regex: true
+                    source_labels:
+                    - __meta_kubernetes_service_annotation_prometheus_io_probe
+                  - source_labels:
+                    - __address__
+                    target_label: __param_target
+                  - replacement: blackbox
+                    target_label: __address__
+                  - source_labels:
+                    - __param_target
+                    target_label: instance
+                  - action: labelmap
+                    regex: __meta_kubernetes_service_label_(.+)
+                  - source_labels:
+                    - __meta_kubernetes_namespace
+                    target_label: namespace
+                  - source_labels:
+                    - __meta_kubernetes_service_name
+                    target_label: service
+                - honor_labels: true
+                  job_name: kubernetes-pods
+                  kubernetes_sd_configs:
+                  - role: pod
+                  relabel_configs:
+                  - action: keep
+                    regex: true
+                    source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+                  - action: drop
+                    regex: true
+                    source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+                  - action: replace
+                    regex: (https?)
+                    source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+                    target_label: __scheme__
+                  - action: replace
+                    regex: (.+)
+                    source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_path
+                    target_label: __metrics_path__
+                  - action: replace
+                    regex: (.+?)(?::\d+)?;(\d+)
+                    replacement: $1:$2
+                    source_labels:
+                    - __address__
+                    - __meta_kubernetes_pod_annotation_prometheus_io_port
+                    target_label: __address__
+                  - action: labelmap
+                    regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+                    replacement: __param_$1
+                  - action: labelmap
+                    regex: __meta_kubernetes_pod_label_(.+)
+                  - action: replace
+                    source_labels:
+                    - __meta_kubernetes_namespace
+                    target_label: namespace
+                  - action: replace
+                    source_labels:
+                    - __meta_kubernetes_pod_name
+                    target_label: pod
+                  - action: drop
+                    regex: Pending|Succeeded|Failed|Completed
+                    source_labels:
+                    - __meta_kubernetes_pod_phase
+                - honor_labels: true
+                  job_name: kubernetes-pods-slow
+                  kubernetes_sd_configs:
+                  - role: pod
+                  relabel_configs:
+                  - action: keep
+                    regex: true
+                    source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+                  - action: replace
+                    regex: (https?)
+                    source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+                    target_label: __scheme__
+                  - action: replace
+                    regex: (.+)
+                    source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_path
+                    target_label: __metrics_path__
+                  - action: replace
+                    regex: (.+?)(?::\d+)?;(\d+)
+                    replacement: $1:$2
+                    source_labels:
+                    - __address__
+                    - __meta_kubernetes_pod_annotation_prometheus_io_port
+                    target_label: __address__
+                  - action: labelmap
+                    regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+                    replacement: __param_$1
+                  - action: labelmap
+                    regex: __meta_kubernetes_pod_label_(.+)
+                  - action: replace
+                    source_labels:
+                    - __meta_kubernetes_namespace
+                    target_label: namespace
+                  - action: replace
+                    source_labels:
+                    - __meta_kubernetes_pod_name
+                    target_label: pod
+                  - action: drop
+                    regex: Pending|Succeeded|Failed|Completed
+                    source_labels:
+                    - __meta_kubernetes_pod_phase
+                  scrape_interval: 5m
+                  scrape_timeout: 30s
+                alerting:
+                  alertmanagers:
+                  - kubernetes_sd_configs:
+                      - role: pod
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                    relabel_configs:
+                    - source_labels: [__meta_kubernetes_namespace]
+                      regex: default
+                      action: keep
+                    - source_labels: [__meta_kubernetes_pod_label_app]
+                      regex: prometheus
+                      action: keep
+                    - source_labels: [__meta_kubernetes_pod_label_component]
+                      regex: alertmanager
+                      action: keep
+                    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_probe]
+                      regex: .*
+                      action: keep
+                    - source_labels: [__meta_kubernetes_pod_container_port_number]
+                      regex: "9093"
+                      action: keep
+                """##
+			"recording_rules.yml": "{}"
+			"rules":               "{}"
+		}
+	}]
+}

--- a/addons/prometheus-server/resources/prometheus-server.cue
+++ b/addons/prometheus-server/resources/prometheus-server.cue
@@ -1,0 +1,196 @@
+package main
+
+prometheusServer: {
+	name: "prometheus-server"
+	type: "webservice"
+	dependsOn: ["prometheus-config"]
+	properties: {
+		image:           parameter["image"]
+		imagePullPolicy: parameter["imagePullPolicy"]
+		livenessProbe: httpGet: {
+			path: "/-/healthy"
+			port: 9090
+		}
+		readinessProbe: httpGet: {
+			path: "/-/ready"
+			port: 9090
+		}
+		ports: [{
+			name: "http"
+			port: 9090
+		}]
+		if parameter["storage"] == "" {
+			volumeMounts: emptyDir: [{
+				name:      "storage-volume"
+				mountPath: "/data"
+			}]
+		}
+		if parameter["storage"] != "" {
+			volumeMounts: pvc: [{
+				name:      "storage-volume"
+				mountPath: "/data"
+				claimName: "prometheus-server-storage"
+			}]
+		}
+		_cms: [{
+			name:      "bootconfig-volume"
+			cmName:    "prometheus-server"
+			mountPath: "/etc/bootconfig"
+		}, {
+			if parameter.customConfig != "" {
+				name:      "custom-config-volume"
+				cmName:    parameter.customConfig
+				mountPath: "/etc/custom"
+			}
+		}]
+		volumeMounts: configMap: [ for cm in _cms if cm.name != _|_ {cm}]
+	}
+	traits: [ for trait in _traits if trait.type != _|_ {trait}]
+	_traits: [{
+		type: "command"
+		properties: args: [
+			"--config.file=/etc/config/prometheus.yml",
+			"--storage.tsdb.path=/data",
+			"--web.console.libraries=/etc/prometheus/console_libraries",
+			"--web.console.templates=/etc/prometheus/consoles",
+			"--web.enable-lifecycle",
+		]
+	}, {
+		type: "init-container"
+		properties: {
+			name:  "init-config"
+			image: "curlimages/curl"
+			args: ["sh", "-c", ##"""
+                NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+                KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+                DEPLOYNAME=$(echo $HOSTNAME | sed -r 's/(.+)-[^-]+-[^-]+/\1/g')
+                curl -sSk -H "Authorization: Bearer $KUBE_TOKEN" \
+                        https://kubernetes.default/apis/apps/v1/namespaces/$NAMESPACE/deployments/$DEPLOYNAME \
+                    | grep "\"app.oam.dev/cluster\"" | sed -r 's/.+:\s+"(.*)",/\1/g' > /etc/config/cluster.name \
+                && CLS=$(cat /etc/config/cluster.name) \
+                && CLUSTER="${CLS:-local}" \
+                && echo "cluster: $CLUSTER" \
+                && sed s/\$CLUSTER/$CLUSTER/g /etc/bootconfig/prometheus.yml > /etc/config/prometheus.yml
+                """##]
+			mountName:     "config-volume"
+			appMountPath:  "/etc/config"
+			initMountPath: "/etc/config"
+			extraVolumeMounts: [{
+				name:      "bootconfig-volume"
+				mountPath: "/etc/bootconfig"
+			}]
+		}
+	}, {
+		if parameter.customConfig != "" {
+			type: "sidecar"
+			properties: {
+				name:  "prometheus-server-configmap-reload"
+				image: "jimmidyson/configmap-reload:v0.5.0"
+				args: ["--volume-dir=/etc/custom", "--webhook-url=http://127.0.0.1:9090/-/reload"]
+				volumes: [{
+					name: "custom-config-volume"
+					path: "/etc/custom"
+				}]
+			}
+		}
+	}, {
+		if parameter.thanos {
+			type: "json-patch"
+			properties: {
+				operations: [{
+					op:   "add"
+					path: "/spec/template/spec/containers/-"
+					value: {
+						name:  "thanos"
+						image: "quay.io/thanos/thanos:v0.8.0"
+						args: ["sidecar", "--tsdb.path=/data", "--prometheus.url=http://127.0.0.1:9090"]
+						env: [{
+							name: "POD_NAME"
+							valueFrom: fieldRef: fieldPath: "metadata.name"
+						}]
+						ports: [{
+							name:          "http-sidecar"
+							containerPort: 10902
+						}, {
+							name:          "grpc"
+							containerPort: 10901
+						}]
+						livenessProbe: httpGet: {
+							port: 10902
+							path: "/-/healthy"
+						}
+						readinessProbe: httpGet: {
+							port: 10902
+							path: "/-/ready"
+						}
+						volumeMounts: [{
+							name:      "storage-volume"
+							mountPath: "/data"
+						}]
+					}
+				}]
+			}
+		}
+	}, {
+		type: "service-account"
+		properties: {
+			name:   "prometheus-server"
+			create: true
+			privileges: [ for p in _clusterPrivileges {
+				scope: "cluster"
+				{p}
+			}]
+		}
+	}, {
+		type: "resource"
+		properties: {
+			cpu:    parameter["cpu"]
+			memory: parameter["memory"]
+		}
+	}, {
+		type: "expose"
+		properties: {
+			_ports: [{
+				if !parameter.thanos {
+					port: 9090
+				}
+			}, {
+				if parameter.thanos {
+					port: 10902
+				}
+			}, {
+				if parameter.thanos {
+					port: 10901
+				}
+			}]
+			port: [ for p in _ports if p.port != _|_ {p.port}]
+			type: parameter.serviceType
+		}
+	}]
+}
+
+_clusterPrivileges: [{
+	apiGroups: [""]
+	resources: ["nodes", "nodes/proxy", "nodes/metrics", "services", "endpoints", "pods", "ingresses", "configmaps"]
+	verbs: ["get", "list", "watch"]
+}, {
+	apiGroups: ["extensions", "networking.k8s.io"]
+	resources: ["ingresses/status", "ingresses"]
+	verbs: ["get", "list", "watch"]
+}, {
+	nonResourceURLs: ["/metrics"]
+	verbs: ["get"]
+}, {
+	apiGroups: ["apps"]
+	resources: ["deployments"]
+	resourceNames: ["prometheus-server"]
+	verbs: ["get"]
+}, {
+	apiGroups: ["cluster.core.oam.dev"]
+	resources: ["clustergateways", "clustergateways/proxy"]
+	verbs: ["get", "list"]
+}, {
+	apiGroups: [""]
+	resources: ["services"]
+	verbs: ["get", "list"]
+}]

--- a/addons/prometheus-server/resources/prometheus-storage.cue
+++ b/addons/prometheus-server/resources/prometheus-storage.cue
@@ -1,0 +1,16 @@
+package main
+
+prometheusStorage: {
+	name: "prometheus-storage"
+	type: "k8s-objects"
+	properties: objects: [{
+		apiVersion: "v1"
+		kind:       "PersistentVolumeClaim"
+		metadata: name: "prometheus-server-storage"
+		spec: {
+			accessModes: ["ReadWriteOnce"]
+			volumeMode: "Filesystem"
+			resources: requests: storage: parameter["storage"]
+		}
+	}]
+}

--- a/addons/prometheus-server/resources/thanos-query.cue
+++ b/addons/prometheus-server/resources/thanos-query.cue
@@ -1,0 +1,67 @@
+package main
+
+thanosQuery: {
+	name: "thanos-query"
+	type: "webservice"
+	dependsOn: ["prometheus-service"]
+	properties: {
+		image:      "quay.io/thanos/thanos:v0.8.0"
+		exposeType: parameter.serviceType
+		ports: [{
+			name:   "http"
+			port:   9090
+			expose: parameter.serviceType != ""
+		}]
+		livenessProbe: httpGet: {
+			port: 9090
+			path: "/-/healthy"
+		}
+		readinessProbe: httpGet: {
+			port: 9090
+			path: "/-/ready"
+		}
+	}
+	traits: [{
+		type: "command"
+		properties: {
+			args: [
+				"query",
+				"--http-address=0.0.0.0:9090",
+				"--log.level=debug",
+				"--query.replica-label=replica",
+				"--store.sd-files=/etc/config/targets.yaml",
+			]
+		}
+	}, {
+		type: "init-container"
+		properties: {
+			name:  "init-config"
+			image: "curlimages/curl"
+			args: ["sh", "-c", ##"""
+                NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+                KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+                curl -sSk -H "Authorization: Bearer $KUBE_TOKEN" \
+                        https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/namespaces/$NAMESPACE/services?labelSelector=addons.oam.dev/name=prometheus-server,app.oam.dev\/component=prometheus-server \
+                    | grep "\"ip\"" | sed -r 's/.+:\s+"(.*)"/\1/g' > /etc/config/prom-endpoints
+                curl -sSk -H "Authorization: Bearer $KUBE_TOKEN" \
+                        https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/apis/cluster.core.oam.dev/v1alpha1/clustergateways \
+                    | grep "\"name\"" | sed -r 's/.+:\s+"(.*)",/\1/g' > /etc/config/clusters
+                while read cls; do
+                curl -sSk -H "Authorization: Bearer $KUBE_TOKEN" \
+                        https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/apis/cluster.core.oam.dev/v1alpha1/clustergateways/$cls/proxy/api/v1/namespaces/$NAMESPACE/services?labelSelector=addons.oam.dev/name=prometheus-server,app.oam.dev\/component=prometheus-server \
+                    | grep "\"ip\"" | sed -r 's/.+:\s+"(.*)"/\1/g' >> /etc/config/prom-endpoints
+                done < /etc/config/clusters
+                echo "- targets:" > /etc/config/targets.yaml
+                while read ip; do
+                echo "  - $ip:10901" >> /etc/config/targets.yaml
+                done < /etc/config/prom-endpoints
+                """##]
+			mountName:     "config-volume"
+			appMountPath:  "/etc/config"
+			initMountPath: "/etc/config"
+		}
+	}, {
+		type: "service-account"
+		properties: name: "prometheus-server"
+	}]
+}

--- a/addons/prometheus-server/template.cue
+++ b/addons/prometheus-server/template.cue
@@ -1,0 +1,83 @@
+package main
+
+comps: [{
+	type: "k8s-objects"
+	name: parameter.name + "-ns"
+	properties: objects: [{
+		apiVersion: "v1"
+		kind:       "Namespace"
+		metadata: name: parameter.namespace
+	}]
+}, prometheusConfig, prometheusServer, {
+	if parameter.storage != "" {prometheusStorage}
+}, {
+	if parameter.thanos {thanosQuery}
+}]
+
+output: {
+	apiVersion: "core.oam.dev/v1beta1"
+	kind:       "Application"
+	metadata: {
+		name:      parameter.name
+		namespace: "vela-system"
+	}
+	spec: {
+		components: [ for comp in comps if comp.name != _|_ {comp}]
+		policies: [{
+			type: "shared-resource"
+			name: "namespace"
+			properties: rules: [{selector: resourceTypes: ["Namespace"]}]
+		}, {
+			type: "garbage-collect"
+			name: "ignore-recycle-pvc"
+			properties: rules: [{
+				selector: resourceTypes: ["PersistentVolumeClaim"]
+				strategy: "never"
+			}]
+		}, {
+			type: "topology"
+			name: "topology-distributed"
+			properties: {
+				if parameter.clusters != _|_ {
+					clusters: parameter.clusters
+				}
+				if parameter.clusters == _|_ {
+					clusterLabelSelector: {}
+				}
+				namespace: parameter.namespace
+			}
+		}, {
+			type: "topology"
+			name: "topology-centralized"
+			properties: {
+				clusters: ["local"]
+				namespace: parameter.namespace
+			}
+		}, {
+			type: "override"
+			name: "component-ns"
+			properties: selector: [parameter.name + "-ns"]
+		}, {
+			type: "override"
+			name: "component-prometheus"
+			properties: selector: ["prometheus-config", "prometheus-storage", "prometheus-server"]
+		}, {
+			type: "override"
+			name: "component-thanos"
+			properties: selector: ["thanos-query"]
+		}]
+		workflow: steps: [{
+			type: "deploy"
+			name: "deploy-ns"
+			properties: policies: ["component-ns", "topology-distributed"]
+		}, {
+			type: "deploy"
+			name: "deploy-prometheus"
+			properties: policies: ["component-prometheus", "topology-distributed"]
+		}, {
+			type: "deploy"
+			name: "deploy-thanos"
+			properties: policies: ["component-thanos", "topology-centralized"]
+		}]
+	}
+}


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Add prometheus-server addon. 

The prometheus-server addon provides core server part for prometheus installation. If `thanos=true` is set, the prometheus-server will be installed together with the thanos sidecar component, and the `thanos-query` will be installed in the hub cluster to aggregate all the thanos sidecars. You can also use `storage=1G` to leverage persistent storage (which will create PVC for it and not recycle it, the PVC will be able to reuse if you disable this addon and reenable it later).

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->

I have:

- [ ] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [ ] Update addon should modify the `version` in `metadata.yaml` to generate a new version.
