### PR TITLE
[Addon] Upgrade vela-prism to v1.5 and use webservice to replace helm

### DIFF
--- a/addons/vela-prism/metadata.yaml
+++ b/addons/vela-prism/metadata.yaml
@@ -1,5 +1,5 @@
 name: vela-prism
-version: v1.4.0
+version: v1.5.0
 description: "Prism provides API Extensions to the core KubeVela. It works as a Kubernetes Aggregated API Server."
 icon: "https://static.kubevela.net/images/logos/KubeVela%20-03.png"
 url: "https://github.com/kubevela/prism"
@@ -7,10 +7,7 @@ url: "https://github.com/kubevela/prism"
 tags:
   - Official
 
-deployTo:
-  control_plane: true
-
-dependencies:
-  - name: fluxcd
-
 invisible: false
+
+system:
+  vela: ">=v1.5.0-beta.4"

--- a/addons/vela-prism/parameter.cue
+++ b/addons/vela-prism/parameter.cue
@@ -1,0 +1,20 @@
+parameter: {
+
+	// global parameters
+
+	// +usage=The namespace of the vela-prism to be installed
+	namespace: *"vela-system" | string
+	// +usage=The name of the addon application
+	name: "addon-vela-prism"
+
+	// vela-prism parameters
+
+	// +usage=Specify the image of vela-prism
+	image: *"oamdev/vela-prism:v1.5.0" | string
+	// +usage=Specify the imagePullPolicy of the image
+	imagePullPolicy: *"IfNotPresent" | "Never" | "Always"
+	// +usage=Specify the number of CPU units
+	cpu: *0.1 | number
+	// +usage=Specifies the attributes of the memory resource required for the container.
+	memory: *"200Mi" | string
+}

--- a/addons/vela-prism/resources/apiservices.cue
+++ b/addons/vela-prism/resources/apiservices.cue
@@ -1,0 +1,37 @@
+package main
+
+apiServices: {
+	type: "k8s-objects"
+	name: "vela-prism-apiservices"
+	properties: objects: [{
+		apiVersion: "apiregistration.k8s.io/v1"
+		kind:       "APIService"
+		metadata: name: "v1alpha1.prism.oam.dev"
+		spec: {
+			version:              "v1alpha1"
+			group:                "prism.oam.dev"
+			groupPriorityMinimum: 2000
+			versionPriority:      10
+			service: {
+				name:      "vela-prism"
+				namespace: parameter.namespace
+				port:      9443
+			}
+		}
+	}, {
+		apiVersion: "apiregistration.k8s.io/v1"
+		kind:       "APIService"
+		metadata: name: "v1alpha1.o11y.prism.oam.dev"
+		spec: {
+			version:              "v1alpha1"
+			group:                "o11y.prism.oam.dev"
+			groupPriorityMinimum: 2000
+			versionPriority:      10
+			service: {
+				name:      "vela-prism"
+				namespace: parameter.namespace
+				port:      9443
+			}
+		}
+	}]
+}

--- a/addons/vela-prism/resources/parameter.cue
+++ b/addons/vela-prism/resources/parameter.cue
@@ -1,9 +1,0 @@
-parameter: {
-    "replicacount": *1 | int
-    "repository": *"oamdev/vela-prism"|string
-    "tag": *"latest"|string
-    "pullPolicy": *"IfNotPresent"|string
-    "cpu": *"100m"|string
-    "memory": *"200Mi"|string
-    "enabled": *true | bool
-}

--- a/addons/vela-prism/resources/privileges.cue
+++ b/addons/vela-prism/resources/privileges.cue
@@ -1,0 +1,47 @@
+package main
+
+additionalPrivileges: {
+	type: "k8s-objects"
+	name: "vela-prism-additional-privileges"
+	properties: objects: [{
+		apiVersion: "rbac.authorization.k8s.io/v1"
+		kind:       "ClusterRole"
+		metadata: name: "vela-prism:prism-cluster-access-role"
+		rules: [{
+			apiGroups: [ "prism.oam.dev"]
+			resources: [ "clusters"]
+			verbs: [ "get", "list", "watch"]
+		}]
+	}, {
+		apiVersion: "rbac.authorization.k8s.io/v1"
+		kind:       "ClusterRoleBinding"
+		metadata: name: "vela-prism:prism-cluster-access-rolebinding"
+		roleRef: {
+			apiGroup: "rbac.authorization.k8s.io"
+			kind:     "ClusterRole"
+			name:     "vela-prism:prism-cluster-access-role"
+		}
+		subjects: [{
+			kind:     "Group"
+			name:     "kubevela:client"
+			apiGroup: "rbac.authorization.k8s.io"
+		}]
+	}, {
+		apiVersion: "rbac.authorization.k8s.io/v1"
+		kind:       "RoleBinding"
+		metadata: {
+			name:      "vela-prism"
+			namespace: "kube-system"
+		}
+		subjects: [{
+			kind:      "ServiceAccount"
+			name:      "vela-prism"
+			namespace: parameter.namespace
+		}]
+		roleRef: {
+			apiGroup: "rbac.authorization.k8s.io"
+			kind:     "Role"
+			name:     "extension-apiserver-authentication-reader"
+		}
+	}]
+}

--- a/addons/vela-prism/resources/vela-prism.cue
+++ b/addons/vela-prism/resources/vela-prism.cue
@@ -1,27 +1,109 @@
-output: {
-	type: "helm"
+package main
+
+prism: {
+	name: "vela-prism"
+	type: "webservice"
 	properties: {
-		repoType: "helm"
-		url:      "https://charts.kubevela.net/prism"
-		chart:    "vela-prism"
-        values: {
-            replicaCount: parameter["replicacount"]
-
-            image: {
-                  repository: parameter["repository"]
-                  tag: parameter["tag"]
-                  pullPolicy: parameter["pullPolicy"]
-            }
-
-            resources: {
-                limits: {
-                    cpu: parameter["cpu"]
-                    memory: parameter["memory"]
-                }
-            }
-            secureTLS: {
-              enabled: parameter["enabled"]
-            }
-        }
+		image:           parameter["image"]
+		imagePullPolicy: parameter["imagePullPolicy"]
 	}
+	traits: [{
+		type: "expose"
+		properties: port: [9443]
+	}, {
+		type: "service-account"
+		properties: {
+			name:   "vela-prism"
+			create: true
+			privileges: [ for p in _clusterPrivileges {
+				scope: "cluster"
+				{p}
+			}]
+		}
+	}, {
+		type: "command"
+		properties: command: [
+			"vela-prism",
+			"--secure-port=9443",
+			"--feature-gates=APIPriorityAndFairness=false",
+			"--cert-dir=/etc/k8s-apiserver-certs",
+			"--storage-namespace=\(parameter.namespace)",
+		]
+	}, {
+		type: "init-container"
+		properties: {
+			name:  "init-config"
+			image: "oamdev/openssl-curl:0.1.0"
+			cmd: ["sh", "-c", #"""
+				cd /etc/k8s-apiserver-certs;
+				echo "authorityKeyIdentifier=keyid,issuer
+				basicConstraints=CA:FALSE
+				subjectAltName = @alt_names
+				[alt_names]
+				DNS.1 = vela-prism
+				DNS.2 = vela-prism.vela-system.svc" > domain.ext \
+				&& openssl req -x509 -sha256 -days 3650 -newkey rsa:2048 -keyout ca.key -out ca -nodes -subj '/O=kubevela' \
+				&& openssl ecparam -name prime256v1 -genkey -noout -out apiserver.key \
+				&& openssl req -new -key apiserver.key -out apiserver.csr -subj '/O=vela-prism' \
+				&& openssl x509 -req -in apiserver.csr -CA ca -CAkey ca.key -CAcreateserial -extfile domain.ext -out apiserver.crt -days 3650 -sha256 \
+				&& echo "apiserver.crt" \
+				&& cat apiserver.crt \
+				&& export KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) \
+				&& export CA=$(cat ca | base64 | tr -d \\n) \
+				&& echo "caBundle: $CA" \
+				&& export PATCH_DATA='[{"op":"replace","path":"/spec/caBundle","value":"'$CA'"}]' \
+				&& echo "patchData: $PATCH_DATA" \
+				&& curl --request PATCH -sSk -H "Authorization: Bearer $KUBE_TOKEN" -H "Content-Type: application/json-patch+json" \
+					https://kubernetes.default/apis/apiregistration.k8s.io/v1/apiservices/v1alpha1.prism.oam.dev \
+					--data $PATCH_DATA \
+				&& curl --request PATCH -sSk -H "Authorization: Bearer $KUBE_TOKEN" -H "Content-Type: application/json-patch+json" \
+					https://kubernetes.default/apis/apiregistration.k8s.io/v1/apiservices/v1alpha1.o11y.prism.oam.dev \
+					--data $PATCH_DATA
+				"""#]
+			mountName:     "k8s-apiserver-certs"
+			appMountPath:  "/etc/k8s-apiserver-certs"
+			initMountPath: "/etc/k8s-apiserver-certs"
+		}
+	}, {
+		type: "resource"
+		properties: {
+			cpu:    parameter["cpu"]
+			memory: parameter["memory"]
+		}
+	}]
 }
+
+_clusterPrivileges: [{
+	apiGroups: [""]
+	resources: ["namespaces"]
+	verbs: ["get", "watch", "list"]
+}, {
+	apiGroups: ["core.oam.dev"]
+	resources: ["resourcetrackers"]
+	verbs: ["get", "watch", "list"]
+}, {
+	apiGroups: ["admissionregistration.k8s.io"]
+	resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+	verbs: ["get", "list", "watch"]
+}, {
+	apiGroups: ["flowcontrol.apiserver.k8s.io"]
+	resources: ["prioritylevelconfigurations", "flowschemas"]
+	verbs: ["get", "list", "watch"]
+}, {
+	apiGroups: ["authorization.k8s.io"]
+	resources: ["subjectaccessreviews"]
+	verbs: ["*"]
+}, {
+	apiGroups: [""]
+	resources: ["secrets"]
+	verbs: ["get", "watch", "list", "create", "update", "delete", "patch"]
+}, {
+	apiGroups: ["cluster.open-cluster-management.io"]
+	resources: ["managedclusters"]
+	verbs: ["get", "watch", "list"]
+}, {
+	apiGroups: ["apiregistration.k8s.io"]
+	resources: ["apiservices"]
+	resourceNames: ["v1alpha1.prism.oam.dev", "v1alpha1.o11y.prism.oam.dev"]
+	verbs: ["patch"]
+}]

--- a/addons/vela-prism/template.cue
+++ b/addons/vela-prism/template.cue
@@ -1,0 +1,41 @@
+package main
+
+output: {
+	apiVersion: "core.oam.dev/v1beta1"
+	kind:       "Application"
+	metadata: {
+		name:      parameter.name
+		namespace: "vela-system"
+	}
+	spec: {
+		components: [
+			prism,
+			additionalPrivileges,
+			apiServices,
+		]
+		policies: [{
+			type: "topology"
+			name: "topology"
+			properties: {
+				clusters: ["local"]
+			}
+		}, {
+			type: "override"
+			name: "override-core"
+			properties: selector: ["vela-prism"]
+		}, {
+			type: "override"
+			name: "override-prehook"
+			properties: selector: ["vela-prism-apiservices", "vela-prism-additional-privileges"]
+		}]
+		workflow: steps: [{
+			type: "deploy"
+			name: "deploy-prehook"
+			properties: policies: ["topology", "override-prehook"]
+		}, {
+			type: "deploy"
+			name: "deploy-core"
+			properties: policies: ["topology", "override-core"]
+		}]
+	}
+}

--- a/addons/vela-prism/template.yaml
+++ b/addons/vela-prism/template.yaml
@@ -1,6 +1,0 @@
-apiVersion: core.oam.dev/v1beta1
-kind: Application
-metadata:
-  name: vela-prism
-  namespace: vela-system
-spec:


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

1. Upgrade to v1.5 to enable Grafana related apis.
2. Refactor to webservice based addon. Therefore, it does not relies on fluxcd anymore.

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.
