### PR TITLE
[Addon] Fix: resolve fluxcd upgrade issues

### DIFF
--- a/addons/fluxcd/resources/components/args.cue
+++ b/addons/fluxcd/resources/components/args.cue
@@ -5,19 +5,6 @@ controllerArgs: [
 	"--log-level=debug",
 	"--log-encoding=json",
 	// Turn off leader-election, otherwise user cannot upgrade from previous versions.
-	//
-	// Reason:
-	//     Atfer we upgrade fluxcd from 1.3.5 to 2.0.0, new deployment/pods are created,
-	//     they will wait for the leader to step down before they are ready.
-	//
-	//     Since the new pods are waiting, they are not ready. The controller will not 
-    //     gc the leader.
-	//
-	//     So the new pods will keep waiting for the previous leader to step down,
-	//     but the previous leader will not step down (being gc'ed) 
-    //     because the new pods are not ready.
-	//
-	//     This is a deadlock.
-	//
+	// Refer to #429 for details.
 	// "--enable-leader-election",
 ]

--- a/addons/fluxcd/resources/components/args.cue
+++ b/addons/fluxcd/resources/components/args.cue
@@ -4,7 +4,8 @@ controllerArgs: [
 	"--watch-all-namespaces",
 	"--log-level=debug",
 	"--log-encoding=json",
-	// Turn off leader-election, otherwise user cannot upgrade from previous versions.
+	// Turn off leader-election, otherwise user cannot upgrade from 
+    // previous versions (v1.3.5 and earlier).
 	// Refer to #429 for details.
 	// "--enable-leader-election",
 ]

--- a/addons/fluxcd/resources/components/args.cue
+++ b/addons/fluxcd/resources/components/args.cue
@@ -11,10 +11,11 @@ controllerArgs: [
 	//     they will wait for the leader to step down before they are ready.
 	//
 	//     Since the new pods are waiting, they are not ready. The controller will not 
-    //     gc the leader because the new ones are not ready.
+    //     gc the leader.
 	//
 	//     So the new pods will keep waiting for the previous leader to step down,
-	//     but the previous leader will not step down (being gc'ed) because the new pods are not ready.
+	//     but the previous leader will not step down (being gc'ed) 
+    //     because the new pods are not ready.
 	//
 	//     This is a deadlock.
 	//

--- a/addons/fluxcd/resources/components/args.cue
+++ b/addons/fluxcd/resources/components/args.cue
@@ -1,0 +1,22 @@
+package main
+
+controllerArgs: [
+	"--watch-all-namespaces",
+	"--log-level=debug",
+	"--log-encoding=json",
+	// Turn off leader-election, otherwise user cannot upgrade from previous versions.
+	//
+	// Reason:
+	//     Atfer we upgrade fluxcd from 1.3.5 to 2.0.0, new deployment/pods are created,
+	//     they will wait for the leader to step down before they are ready.
+	//
+	//     Since the new pods are waiting, they are not ready. The controller will not 
+    //     gc the leader because the new ones are not ready.
+	//
+	//     So the new pods will keep waiting for the previous leader to step down,
+	//     but the previous leader will not step down (being gc'ed) because the new pods are not ready.
+	//
+	//     This is a deadlock.
+	//
+	// "--enable-leader-election",
+]

--- a/addons/fluxcd/resources/components/helm-controller.cue
+++ b/addons/fluxcd/resources/components/helm-controller.cue
@@ -5,8 +5,7 @@ _rules: [...]
 controllerArgs: [...]
 
 helmController: {
-	// Change deployment name (different from v1.3.5) to make uograde possible.
-	// Refer to #429 for details.
+	// About this name, refer to #429 for details.
 	name: "fluxcd-helm-controller"
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]

--- a/addons/fluxcd/resources/components/helm-controller.cue
+++ b/addons/fluxcd/resources/components/helm-controller.cue
@@ -5,7 +5,8 @@ _rules: [...]
 controllerArgs: [...]
 
 helmController: {
-	// See source-controller.cue for details why changed the name.
+	// Change deployment name (different from v1.3.5) to make uograde possible.
+	// Refer to #429 for details.
 	name: "fluxcd-helm-controller"
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]

--- a/addons/fluxcd/resources/components/helm-controller.cue
+++ b/addons/fluxcd/resources/components/helm-controller.cue
@@ -53,15 +53,10 @@ helmController: {
 		{
 			type: "labels"
 			properties: {
-<<<<<<< HEAD
 				"control-plane": "controller"
 				// This label is kept to avoid breaking existing 
 				// KubeVela e2e tests (makefile e2e-setup).
 				"app": "helm-controller"
-=======
-				"app.kubernetes.io/instance": "flux-system"
-				"control-plane":              "controller"
->>>>>>> 56fbdca (Feat: convert controllers to vela native components)
 			}
 		},
 		{

--- a/addons/fluxcd/resources/components/helm-controller.cue
+++ b/addons/fluxcd/resources/components/helm-controller.cue
@@ -2,9 +2,11 @@ package main
 
 _base: string
 _rules: [...]
+controllerArgs: [...]
 
 helmController: {
-	name: "helm-controller"
+	// See source-controller.cue for details why changed the name.
+	name: "fluxcd-helm-controller"
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]
 	properties: {
@@ -51,21 +53,21 @@ helmController: {
 		{
 			type: "labels"
 			properties: {
+<<<<<<< HEAD
 				"control-plane": "controller"
 				// This label is kept to avoid breaking existing 
 				// KubeVela e2e tests (makefile e2e-setup).
 				"app": "helm-controller"
+=======
+				"app.kubernetes.io/instance": "flux-system"
+				"control-plane":              "controller"
+>>>>>>> 56fbdca (Feat: convert controllers to vela native components)
 			}
 		},
 		{
 			type: "command"
 			properties: {
-				args: [
-					"--watch-all-namespaces",
-					"--log-level=debug",
-					"--log-encoding=json",
-					"--enable-leader-election",
-				]
+				args: controllerArgs
 			}
 		},
 	]

--- a/addons/fluxcd/resources/components/image-automation-controller.cue
+++ b/addons/fluxcd/resources/components/image-automation-controller.cue
@@ -2,9 +2,11 @@ package main
 
 _base: string
 _rules: [...]
+controllerArgs: [...]
 
 imageAutomationController: {
-	name: "image-automation-controller"
+	// See source-controller.cue for details why changed the name.
+	name: "fluxcd-image-automation-controller"
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]
 	properties: {
@@ -60,12 +62,7 @@ imageAutomationController: {
 		{
 			type: "command"
 			properties: {
-				args: [
-					"--watch-all-namespaces",
-					"--log-level=debug",
-					"--log-encoding=json",
-					"--enable-leader-election",
-				]
+				args: controllerArgs
 			}
 		},
 	]

--- a/addons/fluxcd/resources/components/image-automation-controller.cue
+++ b/addons/fluxcd/resources/components/image-automation-controller.cue
@@ -5,7 +5,8 @@ _rules: [...]
 controllerArgs: [...]
 
 imageAutomationController: {
-	// See source-controller.cue for details why changed the name.
+	// Change deployment name (different from v1.3.5) to make uograde possible.
+	// Refer to #429 for details.
 	name: "fluxcd-image-automation-controller"
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]

--- a/addons/fluxcd/resources/components/image-automation-controller.cue
+++ b/addons/fluxcd/resources/components/image-automation-controller.cue
@@ -5,8 +5,7 @@ _rules: [...]
 controllerArgs: [...]
 
 imageAutomationController: {
-	// Change deployment name (different from v1.3.5) to make uograde possible.
-	// Refer to #429 for details.
+	// About this name, refer to #429 for details.
 	name: "fluxcd-image-automation-controller"
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]

--- a/addons/fluxcd/resources/components/image-reflector-controller.cue
+++ b/addons/fluxcd/resources/components/image-reflector-controller.cue
@@ -2,9 +2,11 @@ package main
 
 _base: string
 _rules: [...]
+controllerArgs: [...]
 
 imageReflectorController: {
-	name: "image-reflector-controller"
+	// See source-controller.cue for details why changed the name.
+	name: "fluxcd-image-reflector-controller"
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]
 	properties: {
@@ -64,12 +66,7 @@ imageReflectorController: {
 		{
 			type: "command"
 			properties: {
-				args: [
-					"--watch-all-namespaces",
-					"--log-level=debug",
-					"--log-encoding=json",
-					"--enable-leader-election",
-				]
+				args: controllerArgs
 			}
 		},
 	]

--- a/addons/fluxcd/resources/components/image-reflector-controller.cue
+++ b/addons/fluxcd/resources/components/image-reflector-controller.cue
@@ -5,8 +5,7 @@ _rules: [...]
 controllerArgs: [...]
 
 imageReflectorController: {
-	// Change deployment name (different from v1.3.5) to make uograde possible.
-	// Refer to #429 for details.
+	// About this name, refer to #429 for details.
 	name: "fluxcd-image-reflector-controller"
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]

--- a/addons/fluxcd/resources/components/image-reflector-controller.cue
+++ b/addons/fluxcd/resources/components/image-reflector-controller.cue
@@ -5,7 +5,8 @@ _rules: [...]
 controllerArgs: [...]
 
 imageReflectorController: {
-	// See source-controller.cue for details why changed the name.
+	// Change deployment name (different from v1.3.5) to make uograde possible.
+	// Refer to #429 for details.
 	name: "fluxcd-image-reflector-controller"
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]

--- a/addons/fluxcd/resources/components/kustomize-controller.cue
+++ b/addons/fluxcd/resources/components/kustomize-controller.cue
@@ -5,7 +5,8 @@ _rules: [...]
 controllerArgs: [...]
 
 kustomizeController: {
-	// See source-controller.cue for details why changed the name.
+	// Change deployment name (different from v1.3.5) to make uograde possible.
+	// Refer to #429 for details.
 	name: "fluxcd-kustomize-controller"
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]

--- a/addons/fluxcd/resources/components/kustomize-controller.cue
+++ b/addons/fluxcd/resources/components/kustomize-controller.cue
@@ -5,8 +5,7 @@ _rules: [...]
 controllerArgs: [...]
 
 kustomizeController: {
-	// Change deployment name (different from v1.3.5) to make uograde possible.
-	// Refer to #429 for details.
+	// About this name, refer to #429 for details.
 	name: "fluxcd-kustomize-controller"
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]

--- a/addons/fluxcd/resources/components/kustomize-controller.cue
+++ b/addons/fluxcd/resources/components/kustomize-controller.cue
@@ -2,9 +2,11 @@ package main
 
 _base: string
 _rules: [...]
+controllerArgs: [...]
 
 kustomizeController: {
-	name: "kustomize-controller"
+	// See source-controller.cue for details why changed the name.
+	name: "fluxcd-kustomize-controller"
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]
 	properties: {
@@ -60,12 +62,7 @@ kustomizeController: {
 		{
 			type: "command"
 			properties: {
-				args: [
-					"--watch-all-namespaces",
-					"--log-level=debug",
-					"--log-encoding=json",
-					"--enable-leader-election",
-				]
+				args: controllerArgs
 			}
 		},
 	]

--- a/addons/fluxcd/resources/components/source-controller.cue
+++ b/addons/fluxcd/resources/components/source-controller.cue
@@ -6,8 +6,7 @@ controllerArgs: [...]
 _sourceControllerName: "fluxcd-source-controller"
 
 sourceController: {
-	// Change deployment name (different from v1.3.5) to make uograde possible.
-	// Refer to #429 for details.
+	// About this name, refer to #429 for details.
 	name: _sourceControllerName
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]

--- a/addons/fluxcd/resources/components/source-controller.cue
+++ b/addons/fluxcd/resources/components/source-controller.cue
@@ -28,7 +28,7 @@ sourceController: {
 	dependsOn: ["fluxcd-ns"]
 	properties: {
 		imagePullPolicy: "IfNotPresent"
-		image:           _base + "fluxcd/source-controller:v0.25.2"
+		image:           _base + "fluxcd/source-controller:v0.25.1"
 		env: [
 			{
 				name:  "RUNTIME_NAMESPACE"

--- a/addons/fluxcd/resources/components/source-controller.cue
+++ b/addons/fluxcd/resources/components/source-controller.cue
@@ -6,23 +6,8 @@ controllerArgs: [...]
 _sourceControllerName: "fluxcd-source-controller"
 
 sourceController: {
-	// Change deployment name to make uograde possible.
-	//
-	// Reason:
-	//     If we don't change the name, the upgrade *seems* fine, everything works,
-	//     but the actual deployment is not upgraded, which is not what we want.
-	//
-	//     Background:
-	//         The app.oam.dev/component is immutable, we cannot edit it.
-	//
-	//     The original fluxcd is in yaml, but the new ones are using webservice.
-	//     It will try to edit app.oam.dev/component. 
-	//     **This will fail.**
-	//
-	//     Instead, we change a name, to recreate pod. So that do don't modify the label.
-	//
-	//     This name-changing is only required once. After the user upgrades to webserive,
-	//     later upgrades do *not* need to change the name.
+	// Change deployment name (different from v1.3.5) to make uograde possible.
+	// Refer to #429 for details.
 	name: _sourceControllerName
 	type: "webservice"
 	dependsOn: ["fluxcd-ns"]

--- a/addons/fluxcd/resources/rbac/privileges.cue
+++ b/addons/fluxcd/resources/rbac/privileges.cue
@@ -12,7 +12,8 @@ _rules: [
 			"*",
 		]
 		scope: "cluster"
-	}, {
+	},
+	{
 		apiGroups: [
 			"kustomize.toolkit.fluxcd.io",
 		]
@@ -23,7 +24,8 @@ _rules: [
 			"*",
 		]
 		scope: "cluster"
-	}, {
+	},
+	{
 		apiGroups: [
 			"helm.toolkit.fluxcd.io",
 		]
@@ -34,7 +36,8 @@ _rules: [
 			"*",
 		]
 		scope: "cluster"
-	}, {
+	},
+	{
 		apiGroups: [
 			"image.toolkit.fluxcd.io",
 		]
@@ -45,7 +48,8 @@ _rules: [
 			"*",
 		]
 		scope: "cluster"
-	}, {
+	},
+	{
 		apiGroups: [
 			"",
 		]
@@ -61,7 +65,8 @@ _rules: [
 			"watch",
 		]
 		scope: "cluster"
-	}, {
+	},
+	{
 		apiGroups: [
 			"",
 		]
@@ -73,7 +78,8 @@ _rules: [
 			"patch",
 		]
 		scope: "cluster"
-	}, {
+	},
+	{
 		apiGroups: [
 			"",
 		]
@@ -90,7 +96,8 @@ _rules: [
 			"delete",
 		]
 		scope: "cluster"
-	}, {
+	},
+	{
 		apiGroups: [
 			"",
 		]
@@ -103,7 +110,8 @@ _rules: [
 			"patch",
 		]
 		scope: "cluster"
-	}, {
+	},
+	{
 		apiGroups: [
 			"coordination.k8s.io",
 		]


### PR DESCRIPTION
### Description of your changes

Although the user seems can upgrade from old versions of fluxcd, and continue to use it, but the upgrade process is actually not completed. 
The reason why the user can continue to use fluxcd after upgrading is because the upgrade didn't even happen.

This pr makes the upgrade possible.

Reason:


```
Turn off leader-election, otherwise user cannot upgrade from previous versions.

Reason:
    Atfer we upgrade fluxcd from 1.3.5 to 2.0.0, new deployment/pods are created.
    The new ones will NOT be ready until the leader (previous pods) stepped down.

    The previous leader will step down only when being GC'ed, but the GC will not happen
    before the new pods are ready.

    So the new pods will keep waiting for the previous leader to step down,
    but the previous leader will never step down.

    See? This is a deadlock.
```

```
Change deployment name to make uograde possible.

Background:
    The app.oam.dev/component is immutable, we cannot edit it.

Reason:
    The original fluxcd (v1.3.5 and earlier) is in raw yaml, 
    but the new ones (v2.0.0 and later) are using webservice.
    
    When we upgrade from v1.3.5 -> 2.0.0, 
    it will try to edit app.oam.dev/component label.
    
    **This will fail.**

    Instead, we can change a name, to force recreating the deployment
    So that don't modify the original label, just create a new deployment.

    This name-changing is only required once.
    After the user upgrades to webserive (v2.0.0), later upgrades do *not* 
    need to change the name.
```

### How has this code been tested?

User can upgrade from 1.3.5 -> 2.0.0. New charts can be installed as expected.

```bash
vela addon enable fluxcd --version 1.3.5
vela addon upgrade ./fluxcd 
# new pods/deployments of fluxcd controllers will be upgraded correctly, with actual new versions
vela addon enable dex 
# dex is a helm chart, which will be installed correctly
```

Tested later 2.0.0+ upgrades do not make such changes again and can be successfully upgraded

### Checklist

<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [ ] Update addon should modify the `version` in `metadata.yaml` to generate a new version.
