### PR TITLE
[Addon] Bump terraform to 1.0.12

### DIFF
--- a/addons/terraform/metadata.yaml
+++ b/addons/terraform/metadata.yaml
@@ -1,5 +1,5 @@
 name: terraform
-version: 1.0.11
+version: 1.0.12
 description: Terraform Controller is a Kubernetes Controller for Terraform.
 icon: https://static.kubevela.net/images/logos/terraform.png
 url: https://github.com/oam-dev/terraform-controller

--- a/addons/terraform/readme.md
+++ b/addons/terraform/readme.md
@@ -18,3 +18,4 @@ A Kubernetes [Terraform Controller](https://github.com/oam-dev/terraform-control
 | 1.0.9           |        v0.7.4        |      1.0.2       | alicloud 1.140.0; random 3.1.0 |
 | 1.0.10          |        v0.7.4        |      1.0.2       | alicloud 1.140.0; random 3.1.0 |
 | 1.0.11          |        v0.7.5        |      1.0.2       | alicloud 1.140.0; random 3.1.0 |
+| 1.0.12          |        v0.7.6        |      1.0.2       | alicloud 1.140.0; random 3.1.0 |

--- a/addons/terraform/resources/terraform-controller.cue
+++ b/addons/terraform/resources/terraform-controller.cue
@@ -4,7 +4,7 @@ output: {
 		repoType: "helm"
 		url:      "https://charts.kubevela.net/addons"
 		chart:    "terraform-controller"
-		version:  "0.7.5"
+		version:  "0.7.6"
 		values: {}
 	}
 }


### PR DESCRIPTION
There is a bug in Terraform controller v0.7.5. It won't destroy the cloud resources by default. If `Configuration.Spec.DeleteResource` set to false, it'll delete the resource which is not expected behavior.

Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.
