### PR TITLE
[Addon] Add more regular test for terraform

### DIFF
--- a/.github/workflows/addon-test.yaml
+++ b/.github/workflows/addon-test.yaml
@@ -102,8 +102,8 @@ jobs:
 
       - name: Addon e2e-test
         run: |
-          go run test/e2e-test/addon-test/main.go  ${{ steps.changed-files.outputs.all_changed_files }}
-
+          go build -o main test/e2e-test/addon-test/main.go
+          ./main ${{ steps.changed-files.outputs.all_changed_files }}
 
 
 

--- a/test/e2e-test/terraform-test/testdata/rds-database.yaml
+++ b/test/e2e-test/terraform-test/testdata/rds-database.yaml
@@ -1,14 +1,14 @@
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: app-db-1
+  name: app-rds-database
 spec:
   components:
-    - name: demo-database-1
+    - name: sample-rds-database
       type: alibaba-rds-database
       properties:
         region: cn-hangzhou
         existing_instance_id: FAKE_ID
         database_name: first_database
-        password: fake_password
+        password: U34rfwefwefffaked
         account_name: first_db_account

--- a/test/e2e-test/terraform-test/testdata/rds-database.yaml
+++ b/test/e2e-test/terraform-test/testdata/rds-database.yaml
@@ -1,0 +1,14 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-db-1
+spec:
+  components:
+    - name: demo-database-1
+      type: alibaba-rds-database
+      properties:
+        region: cn-hangzhou
+        existing_instance_id: FAKE_ID
+        database_name: first_database
+        password: fake_password
+        account_name: first_db_account

--- a/test/e2e-test/terraform-test/testdata/rds-instance.yaml
+++ b/test/e2e-test/terraform-test/testdata/rds-instance.yaml
@@ -1,0 +1,12 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-rds-instance
+spec:
+  components:
+    - name: sample-rds-instance
+      type: alibaba-rds-instance
+      properties:
+        instance_name: test_single_instance
+        region: cn-hangzhou
+

--- a/test/e2e-test/terraform-test/testdata/redis.yaml
+++ b/test/e2e-test/terraform-test/testdata/redis.yaml
@@ -1,0 +1,15 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: regular-check-rds
+spec:
+  components:
+    - name: sample-redis
+      type: alibaba-redis
+      properties:
+        instance_name: sample-redis
+        accounts:
+          - account_name: oamtest
+            account_password: U34rfwefwefffaked
+        writeConnectionSecretToRef:
+          name: redis-conn


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes

Add: rds, rds-instance, rds-database, redis definition test suite
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [ ] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

### Verified Addon Contribution


I have:

- A new addon added in this repo should be put in as an experimental one unless you have test for a long time in your product environment and be approved by most maintainers.

- An experimental addon must meet these conditions to be promoted as a verified one.

  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.

  - This addon must have some basic but necessary information.

    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
      
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).