### PR TITLE
[Addon] Fix for azure-keyvault-csi trait patch with other volumeMounts

### DIFF
--- a/experimental/addons/azure-keyvault-csi/definitions/azure-keyvault-csi.cue
+++ b/experimental/addons/azure-keyvault-csi/definitions/azure-keyvault-csi.cue
@@ -35,6 +35,7 @@ template: {
           }
         },]
         containers: [{
+          // +patchKey=name
           volumeMounts: [{
             mountPath: "/mnt/secrets-store",
             name: "secrets-store",

--- a/experimental/addons/azure-keyvault-csi/metadata.yaml
+++ b/experimental/addons/azure-keyvault-csi/metadata.yaml
@@ -1,5 +1,5 @@
 name: azure-keyvault-csi
-version: 0.0.1
+version: 0.0.2
 system:
   vela: ">=v1.4.0"
 description: Trait providing access to Azure Keyvault values via csi driver


### PR DESCRIPTION
<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes

Corrects an issue with azure-keyvault-csi trait where the patch to add the secrets-store volume does not correctly patch when there are existing volumeMounts, causing the component deployment to fail .

Fixes #462

### How has this code been tested?

With and without the change own cluster where problem was first detected.

### Checklist

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [x] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [x] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

