### PR TITLE
[Addon] Fix istio addon k8s-objects

### DIFF
--- a/experimental/addons/istio/template.yaml
+++ b/experimental/addons/istio/template.yaml
@@ -17,10 +17,10 @@ spec:
       type: k8s-objects
       properties:
         objects:
-        apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: istio-system
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: istio-system
     - name: istio
       type: helm
       properties:


### PR DESCRIPTION
<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes

When enabling the `istio` addon with `vela enable addon istio`

I was getting this error:


 
```sh
E0910 18:42:34.758361   48962 addon.go:1052] fail to create application: admission webhook "validating.core.oam.dev.v1beta1.applications" denied the request: field "schematic": Invalid value error encountered, cannot create the validation process context of app=addon-istio in namespace=vela-system: evaluate base template app=addon-istio in namespace=vela-system: invalid cue template of workload ns-istio-system after merge parameter and context: output: invalid operation null & [, ...{}] (mismatched types null and list) (and 2 more errors).
Error: fail to create application: admission webhook "validating.core.oam.dev.v1beta1.applications" denied the request: field "schematic": Invalid value error encountered, cannot create the validation process context of app=addon-istio in namespace=vela-system: evaluate base template app=addon-istio in namespace=vela-system: invalid cue template of workload ns-istio-system after merge parameter and context: output: invalid operation null & [, ...{}] (mismatched types null and list) (and 2 more errors).

```

I figured that `spec.components.properties.objects` in `template.yaml` was misconfigured.

It was easy to fix.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

- run `vela addon enable experimental/addons/istio/`

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [ ] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

### Verified Addon Contribution


I have:

- A new addon added in this repo should be put in as an experimental one unless you have test for a long time in your product environment and be approved by most maintainers.

- An experimental addon must meet these conditions to be promoted as a verified one.

  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.

  - This addon must have some basic but necessary information.

    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
      
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).