### PR TITLE
[Addon ] add patch labels  for helm trait

### DIFF
--- a/addons/fluxcd/definitions/patch-labels-helm.cue
+++ b/addons/fluxcd/definitions/patch-labels-helm.cue
@@ -1,0 +1,40 @@
+"patch-labels-helm": {
+	attributes: {
+		podDisruptive: false
+	}
+	description: "Patch labels for helm component's workloads"
+	labels: {
+		"ui-hidden": "true"
+	}
+	type: "trait"
+	attributes: {
+		appliesToWorkloads: ["HelmRelease.helm.toolkit.fluxcd.io"]
+	}
+}
+
+template: {
+	patch: spec: postRenderers: [{
+		kustomize: patchesStrategicMerge: [{
+			apiVersion: parameter.apiVersion
+			kind:       parameter.kind
+			metadata: {
+				name:      context.name
+				namespace: context.namespace
+			}
+			spec: template: metadata: labels: {
+				 "app.oam.dev/component": context.name
+				 "app.oam.dev/name": context.appName
+				 for k, v in parameter.labels {
+				 	   (k): v
+				 }
+			}
+		}]
+	}]
+
+	parameter: {
+		apiVersion: *"apps/v1" | string
+		kind:       *"Deployment" | string
+		name:       *context.name | string
+		labels?:    [string]: string
+	}
+}

--- a/addons/fluxcd/metadata.yaml
+++ b/addons/fluxcd/metadata.yaml
@@ -1,5 +1,5 @@
 name: fluxcd
-version: 2.1.2
+version: 2.1.3
 description: Extended workload to do continuous and progressive delivery
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/flux/horizontal/color/flux-horizontal-color.png
 url: https://fluxcd.io

--- a/examples/fluxcd/helm-comp-stdout-logs.yaml
+++ b/examples/fluxcd/helm-comp-stdout-logs.yaml
@@ -1,0 +1,21 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: nginx-helm
+  namespace: default
+spec:
+  components:
+    - name: nginx-helm
+      type: helm
+      properties:
+        repoType: "helm"
+        url: https://charts.bitnami.com/bitnami
+        chart:  nginx
+        values:
+          service:
+            type: ClusterIP
+      traits:
+        - type: patch-labels-helm
+        - type: stdout-logs
+          properties:
+            parser: nginx


### PR DESCRIPTION
Signed-off-by: wangyike.wyk <wangyike.wyk@alibaba-inc.com>

Since our `std-logs` trait can collect pods' logs with "app.oam.dev/component" and "app.oam.dev/name" label. But these labels are not exist on workload in helm chart. This trait can patch these labels on pods, so that these pods can be collected by loki.

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: nginx-helm
  namespace: default
spec:
  components:
    - name: nginx-helm
      type: helm
      properties:
        repoType: "helm"
        url: https://charts.bitnami.com/bitnami
        chart:  nginx
        values:
          service:
            type: ClusterIP
      traits:
        - type: patch-labels-for-helm-comp
        - type: stdout-logs
          properties:
            parser: nginx
```

![image](https://user-images.githubusercontent.com/77846369/199911599-f3bad7de-9470-48d0-9f05-163762d0507f.png)


<!--
Thank you for contributing to KubeVela Addons!

A new addon added in this repo should be put in as an experimental one unless you have test for a long time in your product environment and be approved by most maintainers.

An experimental addon must meet some conditions to be promoted as a verified one.

-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. 
-->

I have:

- [ ] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [ ] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

If this pr wants to promote an experimental addon to verified, you must check whether meet these conditions too:
  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.
  - This addon must have some basic but necessary information.
    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).