### PR TITLE
[Addon] Allow secret alias in azure-keyvault-csi trait

### DIFF
--- a/experimental/addons/azure-keyvault-csi/definitions/azure-keyvault-csi.cue
+++ b/experimental/addons/azure-keyvault-csi/definitions/azure-keyvault-csi.cue
@@ -16,7 +16,11 @@ import "strings"
 template: {
     kvObjects: [
         for v in parameter.keys {
-            "  objectName: " + v.name + "\n" + "  objectType: " + v.type
+            let object= "  objectName: " + v.name + "\n  objectType: " + v.type
+            {
+              if v.alias != _|_ { object +"\n  objectAlias: " + v.alias }
+              if v.alias == _|_ { object }
+            }
         },
     ]
 
@@ -73,6 +77,8 @@ template: {
         name: string
         // +usage="secret" (default).  Or "key" or "cert" if key contains a certificate - see https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/configurations/getting-certs-and-keys/#how-to-obtain-the-certificate
         type: *"secret" | "key" | "cert"
+        // +usage=changed name to use for mounted secret file, if omitted, will be value of name
+        alias?: string
       }]
       // +usage=The Azure KeyVault to connect to
       keyvaultName:           string

--- a/experimental/addons/azure-keyvault-csi/metadata.yaml
+++ b/experimental/addons/azure-keyvault-csi/metadata.yaml
@@ -1,7 +1,7 @@
 name: azure-keyvault-csi
-version: 0.0.2
+version: 0.0.3
 system:
-  vela: ">=v1.4.0"
+  vela: ">=v1.6.0"
 description: Trait providing access to Azure Keyvault values via csi driver
 url: https://github.com/Azure/secrets-store-csi-driver-provider-azure
 


### PR DESCRIPTION
### Description of your changes

Allow the ability to mount secrets int `\mnt\secrets-store` with a different name than that of the key.

To use this, specify the optional `alias` value on a key.  If not given, the mounted name will be the same as the key name.

### How has this code been tested?

Used in local environment.

### Checklist

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [x] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [x] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.
