### PR TITLE
[Addon] Add optional field sourceName for kustomize

### DIFF
--- a/addons/fluxcd/definitions/kustomize.cue
+++ b/addons/fluxcd/definitions/kustomize.cue
@@ -24,7 +24,12 @@ template: {
 				if parameter.repoType == "oss" {
 					kind: "Bucket"
 				}
-				name:      context.name
+				if parameter.sourceName == _|_ {
+					name: context.name
+				}
+				if parameter.sourceName != _|_ {
+					name: parameter.sourceName
+				}
 				namespace: context.namespace
 			}
 			path:    parameter.path
@@ -38,42 +43,44 @@ template: {
 	}
 
 	outputs: {
-		repo: {
-			apiVersion: "source.toolkit.fluxcd.io/v1beta2"
-			metadata: {
-				name:      context.name
-				namespace: context.namespace
-			}
-			if parameter.repoType == "git" {
-				kind: "GitRepository"
-				spec: {
-					url: parameter.url
-					if parameter.git.branch != _|_ {
-						ref: branch: parameter.git.branch
-					}
-					if parameter.git.provider != _|_ {
-						if parameter.git.provider == "GitHub" {
-							gitImplementation: "go-git"
-						}
-						if parameter.git.provider == "AzureDevOps" {
-							gitImplementation: "libgit2"
-						}
-					}
-					_secret
-					_sourceCommonArgs
+		if parameter.sourceName == _|_ {
+			repo: {
+				apiVersion: "source.toolkit.fluxcd.io/v1beta2"
+				metadata: {
+					name:      context.name
+					namespace: context.namespace
 				}
-			}
-			if parameter.repoType == "oss" {
-				kind: "Bucket"
-				spec: {
-					endpoint:   parameter.url
-					bucketName: parameter.oss.bucketName
-					provider:   parameter.oss.provider
-					if parameter.oss.region != _|_ {
-						region: parameter.oss.region
+				if parameter.repoType == "git" {
+					kind: "GitRepository"
+					spec: {
+						url: parameter.url
+						if parameter.git.branch != _|_ {
+							ref: branch: parameter.git.branch
+						}
+						if parameter.git.provider != _|_ {
+							if parameter.git.provider == "GitHub" {
+								gitImplementation: "go-git"
+							}
+							if parameter.git.provider == "AzureDevOps" {
+								gitImplementation: "libgit2"
+							}
+						}
+						_secret
+						_sourceCommonArgs
 					}
-					_secret
-					_sourceCommonArgs
+				}
+				if parameter.repoType == "oss" {
+					kind: "Bucket"
+					spec: {
+						endpoint:   parameter.url
+						bucketName: parameter.oss.bucketName
+						provider:   parameter.oss.provider
+						if parameter.oss.region != _|_ {
+							region: parameter.oss.region
+						}
+						_secret
+						_sourceCommonArgs
+					}
 				}
 			}
 		}
@@ -209,6 +216,9 @@ template: {
 		secretRef?: string
 		// +usage=The timeout for operations like download index/clone repository, optional
 		timeout?: string
+		// +usage=The name of the source already existed
+		sourceName?: string
+
 		git?: {
 			// +usage=The Git reference to checkout and monitor for changes, defaults to master branch
 			branch: string

--- a/addons/fluxcd/metadata.yaml
+++ b/addons/fluxcd/metadata.yaml
@@ -1,5 +1,5 @@
 name: fluxcd
-version: 2.1.3
+version: 2.1.4
 description: Extended workload to do continuous and progressive delivery
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/flux/horizontal/color/flux-horizontal-color.png
 url: https://fluxcd.io


### PR DESCRIPTION
<!--
Thank you for contributing to KubeVela Addons!

A new addon added in this repo should be put in as an experimental one unless you have test for a long time in your product environment and be approved by most maintainers.

An experimental addon must meet some conditions to be promoted as a verified one.

-->

### Description of your changes
- Add `sourceName` optional field similar to #493 

Ref: https://github.com/kubevela/kubevela/issues/4820

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

1. I use the manifest in https://github.com/chengleqi/argocd-example-apps repo master branch `./nginx` path to generate a kustomize app named `test-kus-nginx`. It generated a kustomization named `test-kus-nginx` and a gitrepo named `test-kus-nginx`.

2. Then I create another kustomize app named `test-kus-nginx-sourcename` which `sourceName` field is `test-kus-nginx` indicated to the name of the gitrepo generated by the `test-kus-nginx` kustomize.

---
Check the state finally.

```shell
❯ flux get source git -A
NAMESPACE	NAME          	REVISION      	SUSPENDED	READY	MESSAGE
default  	test-kus-nginx	master/92ce5d2	False    	True 	stored artifact for revision 'master/92ce5d216c2bb1b443bbeabad0d0ac4db07424da'

❯ flux get ks -A
NAMESPACE	NAME                     	REVISION      	SUSPENDED	READY	MESSAGE
default  	test-kus-nginx-sourcename	master/92ce5d2	False    	True 	Applied revision: master/92ce5d2
default  	test-kus-nginx           	master/92ce5d2	False    	True 	Applied revision: master/92ce5d2
```


<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. 
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

If this pr wants to promote an experimental addon to verified, you must check whether meet these conditions too:
  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.
  - This addon must have some basic but necessary information.
    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).