### PR TITLE
[Addon]: add support for k8s 1.24+ for install k8s api for o11y-definitions

### DIFF
--- a/addons/o11y-definitions/definitions/install-kubernetes-api-datasource.cue
+++ b/addons/o11y-definitions/definitions/install-kubernetes-api-datasource.cue
@@ -24,26 +24,65 @@ template: {
 		}
 	} @step(1)
 
-	wait: op.#ConditionalWait & {
-		continue: readSA.value.secrets != _|_ && len(readSA.value.secrets) > 0
+	createSecret: op.#Apply & {
+		value: {
+			apiVersion: "v1"
+			kind:       "Secret"
+			metadata: {
+				name:      parameter.serviceAccountName + "-autogen"
+				namespace: parameter.namespace
+				annotations: "kubernetes.io/service-account.name": parameter.serviceAccountName
+			}
+			type: "kubernetes.io/service-account-token"
+		}
 	} @step(2)
+
+	getSecret: op.#Read & {
+		value: {
+			apiVersion: "v1"
+			kind:       "Secret"
+			metadata: {
+				name:      parameter.serviceAccountName + "-autogen"
+				namespace: parameter.namespace
+			}
+		}
+	} @step(3)
+
+	wait: op.#ConditionalWait & {
+		continue: *false | bool
+		if readSA.value.secrets != _|_ {
+			if len(readSA.value.secrets) > 0 {
+				continue: true
+			}
+		}
+		if getSecret.value.data != _|_ {
+			if getSecret.value.data.token != _|_ {
+				continue: true
+			}
+		}
+	} @step(4)
 
 	read: op.#Read & {
 		value: {
 			apiVersion: "v1"
 			kind:       "Secret"
 			metadata: {
-				name:      readSA.value.secrets[0].name
+				if getSecret.value.data == _|_ || getSecret.value.data.token == _|_ {
+					name: readSA.value.secrets[0].name
+				}
+				if getSecret.value.data != _|_ && getSecret.value.data.token != _|_ {
+					name: parameter.serviceAccountName + "-autogen"
+				}
 				namespace: parameter.namespace
 			}
 		}
-	} @step(3)
+	} @step(5)
 
 	decode: op.#Steps & {
 		token:     base64.Decode(null, read.value.data.token)
 		convert:   op.#ConvertString & {bt: token}
 		kubeToken: convert.str
-	} @step(4)
+	} @step(6)
 
 	output: op.#Apply & {
 		value: {
@@ -66,7 +105,7 @@ template: {
 				}
 			}
 		}
-	} @step(5)
+	} @step(7)
 
 	parameter: {
 		serviceAccountName: *"grafana" | string

--- a/addons/o11y-definitions/metadata.yaml
+++ b/addons/o11y-definitions/metadata.yaml
@@ -1,5 +1,5 @@
 name: o11y-definitions
-version: v0.2.3
+version: v0.2.4
 description: Grafana definitions is an auxiliary addon that creates definitions for grafana installation and use.
 icon: https://artifacthub.io/image/e69a4034-cfe7-4fa8-95ce-df3837f5d717@1x
 url: https://grafana.com/


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>

<!--
Thank you for contributing to KubeVela Addons!

A new addon added in this repo should be put in as an experimental one unless you have test for a long time in your product environment and be approved by most maintainers.

An experimental addon must meet some conditions to be promoted as a verified one.

-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

In addon `o11y-definitions`, there is a workflowstep definition called `install-kubernetes-api-datasource` which install Kubernetes apiserver endpoint as one type of datasource to Grafana.

The underlying logic is to create a ServiceAccount and get the token for it. Then the token will be embedded as the authorization header in Grafana Datasource for access.

In k8s 1.24+, the token will not be generated automatically for the ServiceAccount [1]. This PR supports manually create secret for getting the token while keeping compatibility for the old version k8s.

Reference:
1. https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-an-api-token-for-a-serviceaccount

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. 
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [x] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [x] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

If this pr wants to promote an experimental addon to verified, you must check whether meet these conditions too:
  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.
  - This addon must have some basic but necessary information.
    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).