### PR TITLE
[Addon] Fix the version issue of flink-kubernetes-operator

### DIFF
--- a/addons/flink-kubernetes-operator/metadata.yaml
+++ b/addons/flink-kubernetes-operator/metadata.yaml
@@ -1,5 +1,5 @@
 name: flink-kubernetes-operator
-version: 1.1.0
+version: 1.3.0
 description: A Kubernetes operator for Apache Flink
 icon: https://flink.apache.org/img/logo/png/500/flink_squirrel_500.png
 url: https://github.com/apache/flink-kubernetes-operator

--- a/addons/flink-kubernetes-operator/template.cue
+++ b/addons/flink-kubernetes-operator/template.cue
@@ -22,10 +22,10 @@ output: {
                             type: "helm"
                             properties: {
                                     repoType: "helm"
-                                    url:      "https://downloads.apache.org/flink/flink-kubernetes-operator-1.1.0/"
+                                    url:      "https://downloads.apache.org/flink/flink-kubernetes-operator-1.3.0/"
                                     chart:    "flink-kubernetes-operator"
                                     targetNamespace: parameter["namespace"]
-                                    version:  "1.1.0"
+                                    version:  "1.3.0"
                                     values: {
                                             webhook: {
                                                 create: parameter["createWebhook"]

--- a/test/e2e-test/addon-test/PENDING
+++ b/test/e2e-test/addon-test/PENDING
@@ -3,4 +3,3 @@
 
 ocm-gateway-manager-addon
 model-serving
-flink-kubernetes-operator


### PR DESCRIPTION
<!--
Thank you for contributing to KubeVela Addons!

A new addon added in this repo should be put in as an experimental one unless you have test for a long time in your product environment and be approved by most maintainers.

An experimental addon must meet some conditions to be promoted as a verified one.

-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

changed the version from 1.1.0 to 1.3.0

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

debugged the addon in my local, installed offline:

```
vela addon enable /root/.vela/addons/flink-kubernetes-operator
```

show the status:
```
vela addon status flink-kubernetes-operator
```

the result：

```
flink-kubernetes-operator: enabled (1.3.0)
==> Installed Clusters
[local]
==> Registry Name
local
```

### Checklist

<!--
Please run through the below readiness checklist. 
-->

I have:

- [ ] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [ ] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

If this pr wants to promote an experimental addon to verified, you must check whether meet these conditions too:
  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.
  - This addon must have some basic but necessary information.
    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).