### PR TITLE
[Addon]feat: add advanced options for fluxcd controllers

### DIFF
--- a/addons/fluxcd/metadata.yaml
+++ b/addons/fluxcd/metadata.yaml
@@ -1,5 +1,5 @@
 name: fluxcd
-version: 2.3.1
+version: 2.3.2
 description: Extended workload to do continuous and progressive delivery
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/flux/horizontal/color/flux-horizontal-color.png
 url: https://fluxcd.io

--- a/addons/fluxcd/parameter.cue
+++ b/addons/fluxcd/parameter.cue
@@ -7,4 +7,14 @@ parameter: {
 	namespace: *"flux-system" | string
 	//+usage=OnlyHelmComponents only enable helm associated components, default to false
 	onlyHelmComponents: *false | bool
+	//+usage=advanced options for Helm Controller
+	helmControllerOptions?: [...string]
+	//+usage=advanced options for Source Controller
+	sourceControllerOptions?: [...string]
+	//+usage=advanced options for Kustomize Controller
+	kustomizeControllerOptions?: [...string]
+	//+usage=advanced options for Image Reflector Controller
+	imageReflectorControllerOptions?: [...string]
+	//+usage=advanced options for Image Automation Controller
+	imageAutomationControllerOptions?: [...string]
 }

--- a/addons/fluxcd/resources/components/helm-controller.cue
+++ b/addons/fluxcd/resources/components/helm-controller.cue
@@ -63,7 +63,12 @@ helmController: {
 		{
 			type: "command"
 			properties: {
-				args: controllerArgs
+				if parameter.helmControllerOptions != _|_ {
+					args: controllerArgs + parameter.helmControllerOptions
+				}
+				if parameter.helmControllerOptions == _|_ {
+					args: controllerArgs
+				}
 			}
 		},
 	]

--- a/addons/fluxcd/resources/components/image-automation-controller.cue
+++ b/addons/fluxcd/resources/components/image-automation-controller.cue
@@ -63,7 +63,12 @@ imageAutomationController: {
 		{
 			type: "command"
 			properties: {
-				args: controllerArgs
+				if parameter.imageAutomationControllerOptions != _|_ {
+					args: controllerArgs + parameter.imageAutomationControllerOptions
+				}
+				if parameter.imageAutomationControllerOptions == _|_ {
+					args: controllerArgs
+				}
 			}
 		},
 	]

--- a/addons/fluxcd/resources/components/image-reflector-controller.cue
+++ b/addons/fluxcd/resources/components/image-reflector-controller.cue
@@ -67,7 +67,12 @@ imageReflectorController: {
 		{
 			type: "command"
 			properties: {
-				args: controllerArgs
+				if parameter.imageReflectorControllerOptions != _|_ {
+					args: controllerArgs + parameter.imageReflectorControllerOptions
+				}
+				if parameter.imageReflectorControllerOptions == _|_ {
+					args: controllerArgs
+				}
 			}
 		},
 	]

--- a/addons/fluxcd/resources/components/kustomize-controller.cue
+++ b/addons/fluxcd/resources/components/kustomize-controller.cue
@@ -63,7 +63,12 @@ kustomizeController: {
 		{
 			type: "command"
 			properties: {
-				args: controllerArgs
+				if parameter.kustomizeControllerOptions != _|_ {
+					args: controllerArgs + parameter.kustomizeControllerOptions
+				}
+				if parameter.kustomizeControllerOptions == _|_ {
+					args: controllerArgs
+				}
 			}
 		},
 	]

--- a/addons/fluxcd/resources/components/source-controller.cue
+++ b/addons/fluxcd/resources/components/source-controller.cue
@@ -6,6 +6,11 @@ controllerArgs: [...]
 _targetNamespace: string
 _sourceControllerName: "fluxcd-source-controller"
 
+imageControllerDefaultArgs: controllerArgs + [
+					"--storage-path=/data",
+					"--storage-adv-addr=http://" + _sourceControllerName + "." + _targetNamespace + ".svc:9090",
+]
+
 sourceController: {
 	// About this name, refer to #429 for details.
 	name: _sourceControllerName
@@ -77,10 +82,12 @@ sourceController: {
 		{
 			type: "command"
 			properties: {
-				args: controllerArgs + [
-					"--storage-path=/data",
-					"--storage-adv-addr=http://" + _sourceControllerName + "." + _targetNamespace + ".svc:9090",
-				]
+				if parameter.sourceControllerOptions != _|_ {
+					args: imageControllerDefaultArgs + parameter.sourceControllerOptions
+				}
+				if parameter.sourceControllerOptions == _|_ {
+					args: imageControllerDefaultArgs
+				}	
 			}
 		},
 	]


### PR DESCRIPTION
<!--
Thank you for contributing to KubeVela Addons!

A new addon added in this repo should be put in as an experimental one unless you have test for a long time in your product environment and be approved by most maintainers.

An experimental addon must meet some conditions to be promoted as a verified one.

-->

### Description of your changes

Add advanced parameters to support [options](https://fluxcd.io/flux/components/helm/options/) for fluxcd's controller.

Example:
``` vela addon enable fluxcd clusters="{local}" helmControllerOptions="{--no-cross-namespace-refs,--concurrent=5}"```
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
I have tested on my cluster. 
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. 
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

If this pr wants to promote an experimental addon to verified, you must check whether meet these conditions too:
  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.
  - This addon must have some basic but necessary information.
    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).