### PR TITLE
Fix: add object select label for workload

### DIFF
--- a/addons/kruise-rollout/definitions/rolling-release.cue
+++ b/addons/kruise-rollout/definitions/rolling-release.cue
@@ -108,7 +108,10 @@ template: {
 		}
 	}
 
-	patch: metadata: annotations: "app.oam.dev/disable-health-check": "true"
+	patch: metadata: {
+		 annotations: "app.oam.dev/disable-health-check": "true"
+		 labels:  "kruise-rollout.oam.dev/webhook": "true"
+	}
 
 	outputs: rollout: {
 		apiVersion: "rollouts.kruise.io/v1alpha1"

--- a/addons/kruise-rollout/metadata.yaml
+++ b/addons/kruise-rollout/metadata.yaml
@@ -1,5 +1,5 @@
 name: kruise-rollout
-version: 1.5.0-beta.1
+version: 1.5.0-beta.2
 description: Rollout workload by kruise controller
 url: https://github.com/openkruise/rollouts
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openkruise/stacked/color/openkruise-stacked-color.png

--- a/addons/kruise-rollout/schemas/workflowstep-uischema-canary-deploy.yaml
+++ b/addons/kruise-rollout/schemas/workflowstep-uischema-canary-deploy.yaml
@@ -2,7 +2,7 @@
   jsonKey: policies
   uiType: PolicySelect
 - sort: 30
-  jsonKey: component
+  jsonKey: components
   uiType: ComponentSelect
 - sort: 10
   jsonKey: weight

--- a/addons/kruise-rollout/template.cue
+++ b/addons/kruise-rollout/template.cue
@@ -15,6 +15,12 @@ output: {
 			url:      "https://openkruise.github.io/charts/"
 			chart:    "kruise-rollout"
 			version:  "0.3.0"
+			values: {
+				rollout: webhook: objectSelector: [{
+					 key: "kruise-rollout.oam.dev/webhook"
+					 operator: "Exists"
+				}]
+			}
 		}
 	}]
 }

--- a/examples/kruise/rollout/rollout-with-workflow-v2.yaml
+++ b/examples/kruise/rollout/rollout-with-workflow-v2.yaml
@@ -27,13 +27,13 @@ spec:
         name: rollout-20
         properties:
           weight: 20
-      - name: suspend
+      - name: suspend-1
         type: suspend
       - type: canary-deploy
         name: rollout-50
         properties:
           weight: 50
-      - name: suspend
+      - name: suspend-2
         type: suspend
       - type: canary-deploy
         name: rollout-100


### PR DESCRIPTION
<!--
Thank you for contributing to KubeVela Addons!

A new addon added in this repo should be put in as an experimental one unless you have test for a long time in your product environment and be approved by most maintainers.

An experimental addon must meet some conditions to be promoted as a verified one.

-->

### Description of your changes

The webhook of the rollout controller intercepts all updating requests of deployment. However, if the Kruise Rollout pod crashes, it blocks all deployment operations. This PR addresses the issue by allowing the rollout controller to focus only on deployments that contain the krusie-rollout.oam.dev/webhook label. Additionally, if the workload uses the canary-deploy step, Vela will patch this label on it automatically.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. 
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [x] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [ ] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

If this pr wants to promote an experimental addon to verified, you must check whether meet these conditions too:
  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.
  - This addon must have some basic but necessary information.
    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).