### PR TITLE
[Addon]: add alidns support to cert-manager

### DIFF
--- a/addons/cert-manager/README.md
+++ b/addons/cert-manager/README.md
@@ -46,3 +46,16 @@ cert-manager/certificaterequests-issuer-acme/sign "msg"="certificate issued" "re
 It is time to use your brand-new certificate to a service!
 
 > TODO(charlie0129): I will update this later, with an example to use cert-manager + traefik + nginx to host a TLS-secured website.
+
+## ACME: Auto-Acquire Wildcard TLS Certificates with AliDNS DNS01 Challenge
+
+```console
+vela addon enable cert-manager                       \
+    staging=true                                     \
+    dns01.namespace="default"                        \
+    dns01.alidns.email="your-email@example.com"      \
+    dns01.alidns.accessToken="your-accesstoken-here" \
+    dns01.alidns.secretKey="your-secretKey-here"     \
+    dns01.alidns.regionId="cn-beijing"               \
+    dns01.alidns.groupName="example.com"             \
+```

--- a/addons/cert-manager/metadata.yaml
+++ b/addons/cert-manager/metadata.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 2.1.1
+version: 2.2.0
 description: Automatically provision and manage TLS certificates in Kubernetes
 icon: https://raw.githubusercontent.com/cert-manager/cert-manager/master/logo/logo-small.png
 url: https://github.com/cert-manager/cert-manager

--- a/addons/cert-manager/parameter.cue
+++ b/addons/cert-manager/parameter.cue
@@ -26,5 +26,18 @@ parameter: {
 			//+usage=Your domain apex, e.g. "example.com"
 			domain: string
 		}
+		//+usage=Alidns DNS01 config
+		alidns?: {
+			//+usage=The email associated with your domain
+			email: string
+			//+usage=Alidns API access token. API token should have RW access to your domain
+			accessToken: string
+			//+usage=Alidns API secret key
+			secretKey: string
+			//+usage=Alidns DNS zone
+			regionId: *"" | string
+			//+usage=Your domain apex, e.g. "example.com"
+			groupName: string
+		}
 	}
 }

--- a/addons/cert-manager/resources/alidns-dns01.cue
+++ b/addons/cert-manager/resources/alidns-dns01.cue
@@ -1,0 +1,100 @@
+package main
+
+alidnsWebhook: _
+alidnsTokenSecret: _
+alidnsCertificate: _
+alidnsIssuer:      _
+
+clusterIssuerName: "letsencrypt"
+
+if parameter.dns01 != _|_ && parameter.dns01.alidns != _|_ {
+  alidnsWebhook: {
+    name: "alidns-webhook"
+    type: "helm"
+    dependsOn: ["cert-manager"]
+    properties: {
+      repoType:        "helm"
+      url:             "https://devmachine-fr.github.io/cert-manager-alidns-webhook"
+      chart:           "alidns-webhook"
+      targetNamespace: parameter.namespace
+      version:         "0.6.1"
+      values: {
+        groupName: parameter.dns01.alidns.groupName
+				// set cert-manager service account name according to namespace name
+				certManager: {
+					namespace: parameter.namespace
+					serviceAccountName: parameter.namespace + "-cert-manager"
+				}
+      }
+    }
+  }
+
+	alidnsTokenSecret: {
+		apiVersion: "v1"
+		kind:       "Secret"
+		metadata: {
+			name:      "alidns-token-secret"
+			namespace: parameter.namespace
+		}
+		type: "Opaque"
+		stringData: {
+			"access-token": parameter.dns01.alidns.accessToken
+      "secret-key": parameter.dns01.alidns.secretKey
+		}
+	}
+
+	alidnsCertificate: {
+		apiVersion: "cert-manager.io/v1"
+		kind:       "Certificate"
+		metadata: {
+			name:      "alidns-certificate"
+			namespace: parameter.dns01.namespace
+		}
+		spec: {
+			secretName: alidnsCertificate.metadata.name + "-tls"
+			issuerRef: {
+				name: clusterIssuerName
+				kind: "ClusterIssuer"
+			}
+			commonName: "*." + parameter.dns01.alidns.groupName
+			dnsNames: [
+				parameter.dns01.alidns.groupName,
+				"*." + parameter.dns01.alidns.groupName,
+			]
+		}
+
+	}
+
+	alidnsIssuer: {
+		apiVersion: "cert-manager.io/v1"
+		kind:       "ClusterIssuer"
+		metadata: name: clusterIssuerName
+		spec: acme: {
+			if parameter.staging {
+				server: "https://acme-staging-v02.api.letsencrypt.org/directory"
+			}
+			if !parameter.staging {
+				server: "https://acme-v02.api.letsencrypt.org/directory"
+			}
+			email: parameter.dns01.alidns.email
+			privateKeySecretRef: name: "letsencrypt-private-key"
+			solvers: [{
+				dns01: webhook: {
+          config: {
+            accessTokenSecretRef: {
+              key: "access-token"
+              name: "alidns-token-secret"
+            }
+            secretKeySecretRef: {
+              key: "secret-key"
+              name: "alidns-token-secret"
+            }
+            regionId: parameter.dns01.alidns.regionId
+          }
+					groupName: parameter.dns01.alidns.groupName
+          solverName: "alidns-solver"
+				}
+			}]
+		}
+	}
+}

--- a/addons/cert-manager/template.cue
+++ b/addons/cert-manager/template.cue
@@ -27,6 +27,21 @@ output: {
 					]
 				}
 			},
+			if parameter.dns01 != _|_ && parameter.dns01.alidns != _|_ {
+				alidnsWebhook
+			}
+			if parameter.dns01 != _|_ && parameter.dns01.alidns != _|_ {
+				{
+					type: "k8s-objects"
+					name: "certificate-conf"
+					dependsOn: ["alidns-webhook"]
+					properties: objects: [
+						alidnsTokenSecret,
+						alidnsCertificate,
+						alidnsIssuer,
+					]
+				}
+			},			
 		]
 		policies: [
 			{


### PR DESCRIPTION
### Description of your changes

Add alidns webhook support to cert-manager

### How has this code been tested?

### Checklist

I have:

- [ ] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [ ] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

If this pr wants to promote an experimental addon to verified, you must check whether meet these conditions too:
  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.
  - This addon must have some basic but necessary information.
    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    - [x] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).