### PR TITLE
[Addon] Fix #718 vela-workflow addon serviceaccount labels added in t…

### DIFF
--- a/addons/vela-workflow/resources/privileges.cue
+++ b/addons/vela-workflow/resources/privileges.cue
@@ -7,12 +7,13 @@ additionalPrivileges: {
 		{
 			apiVersion: "v1"
 			kind:       "ServiceAccount"
-			metadata:
+			metadata: {
 				name: "vela-workflow"
-			labels: {
-				"app.kubernetes.io/name":     const.name
-				"app.kubernetes.io/instance": const.name
-				"app.kubernetes.io/version":  parameter.version
+				labels: {
+					"app.kubernetes.io/name":     const.name
+					"app.kubernetes.io/instance": const.name
+					"app.kubernetes.io/version":  parameter.version
+				}
 			}
 		}, {
 			apiVersion: "rbac.authorization.k8s.io/v1"


### PR DESCRIPTION
In vela-workflow, [addon](https://github.com/kubevela/catalog/blob/master/addons/vela-workflow/resources/privileges.cue), the service account (vela-workflow) labels added outside of the metadata section. And Kubernetes doesn't accept any labels outside of the metadata section. 

And I opened an issue for  the same - https://github.com/kubevela/catalog/issues/718