### PR TITLE
[Addon] Fix #718 vela-workflow addon serviceaccount labels added in t…

### DIFF
--- a/addons/vela-workflow/metadata.yaml
+++ b/addons/vela-workflow/metadata.yaml
@@ -1,5 +1,5 @@
 name: vela-workflow
-version: v0.6.0
+version: v0.6.1
 description: "vela-workflow provides the capability to run a standalone workflow"
 icon: "https://static.kubevela.net/images/logos/KubeVela%20-03.png"
 url: "https://github.com/kubevela/workflow"

--- a/addons/vela-workflow/resources/privileges.cue
+++ b/addons/vela-workflow/resources/privileges.cue
@@ -7,12 +7,13 @@ additionalPrivileges: {
 		{
 			apiVersion: "v1"
 			kind:       "ServiceAccount"
-			metadata:
+			metadata: {
 				name: "vela-workflow"
-			labels: {
-				"app.kubernetes.io/name":     const.name
-				"app.kubernetes.io/instance": const.name
-				"app.kubernetes.io/version":  parameter.version
+				labels: {
+					"app.kubernetes.io/name":     const.name
+					"app.kubernetes.io/instance": const.name
+					"app.kubernetes.io/version":  parameter.version
+				}
 			}
 		}, {
 			apiVersion: "rbac.authorization.k8s.io/v1"


### PR DESCRIPTION

The service account (vela-workflow) labels are added outside the metadata section in the vela-workflow addon. And Kubernetes doesn't accept any labels outside of the metadata section.

And I opened an issue for the same - #718