### PR TITLE
[Addon] align all semver format in observability suite

### DIFF
--- a/addons/grafana/metadata.yaml
+++ b/addons/grafana/metadata.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: v0.4.3
+version: 0.4.4
 description: Grafana is a multi-platform open source analytics and interactive visualization web application. It provides charts, graphs, and alerts for the web when connected to supported data sources.
 icon: https://artifacthub.io/image/e69a4034-cfe7-4fa8-95ce-df3837f5d717@1x
 url: https://grafana.com/

--- a/addons/kube-state-metrics/metadata.yaml
+++ b/addons/kube-state-metrics/metadata.yaml
@@ -1,5 +1,5 @@
 name: kube-state-metrics
-version: v0.3.0
+version: 0.3.1
 description: A simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
 icon: https://artifacthub.io/image/81797fec-309d-4380-a527-68f1c9e1dcfb@1x
 url: https://github.com/kubernetes/kube-state-metrics

--- a/addons/loki/metadata.yaml
+++ b/addons/loki/metadata.yaml
@@ -1,5 +1,5 @@
 name: loki
-version: v0.3.1
+version: 0.3.2
 description: Loki is a log aggregation system designed to store and query logs from all your applications and infrastructure.
 icon: https://grafana.com/static/img/logos/logo-loki.svg
 url: https://grafana.com/oss/loki/

--- a/addons/node-exporter/metadata.yaml
+++ b/addons/node-exporter/metadata.yaml
@@ -1,5 +1,5 @@
 name: node-exporter
-version: v0.3.0
+version: 0.3.1
 description: Prometheus exporter for hardware and OS metrics exposed by *NIX kernels, written in Go with pluggable metric collectors.
 icon: https://artifacthub.io/image/0503add5-3fce-4b63-bbf3-b9f649512a86@1x
 url: https://github.com/prometheus/node_exporter

--- a/addons/o11y-definitions/metadata.yaml
+++ b/addons/o11y-definitions/metadata.yaml
@@ -1,5 +1,5 @@
 name: o11y-definitions
-version: v0.3.0
+version: 0.3.1
 description: Grafana definitions is an auxiliary addon that creates definitions for grafana installation and use.
 icon: https://artifacthub.io/image/e69a4034-cfe7-4fa8-95ce-df3837f5d717@1x
 url: https://grafana.com/

--- a/addons/prometheus-server/metadata.yaml
+++ b/addons/prometheus-server/metadata.yaml
@@ -1,5 +1,5 @@
 name: prometheus-server
-version: v0.3.2
+version: 0.3.3
 description: An open-source monitoring system with a dimensional data model, flexible query language, efficient time series database and modern alerting approach.
 icon: https://artifacthub.io/image/0503add5-3fce-4b63-bbf3-b9f649512a86@1x
 url: https://prometheus.io/

--- a/experimental/addons/vector-config/metadata.yaml
+++ b/experimental/addons/vector-config/metadata.yaml
@@ -1,5 +1,5 @@
 name: vector-config
-version: v0.1.0
+version: 0.1.1
 description: Vector is a lightweight, ultra-fast tool for building observability pipelines.
 url: https://vector.dev/
 


### PR DESCRIPTION
<!--
Thank you for contributing to KubeVela Addons!

A new addon added in this repo should be put in as an experimental one unless you have test for a long time in your product environment and be approved by most maintainers.

An experimental addon must meet some conditions to be promoted as a verified one.

-->

### Description of your changes

Vela CLI has an update which is not compatible to `vx.y.z` semver. This PR align all observability addon to `x.y.z` format.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. 
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.