### PR TITLE
[Addon]: VelaUX ingress expose class name parameter

### DIFF
--- a/addons/velaux/parameter.cue
+++ b/addons/velaux/parameter.cue
@@ -13,6 +13,8 @@ parameter: {
 	secretName?: string
 	// +usage=Specify the gateway type.
 	gatewayDriver: *"nginx" | "traefik"
+	// +usage=Set ingress class name in 'kubernetes.io/ingress.class' annotation.
+	class: *"nginx" | string
 	// +usage=Specify the serviceAccountName for apiserver
 	serviceAccountName: *"kubevela-ux" | string
 	// +usage=Specify the service type.

--- a/addons/velaux/parameter.cue
+++ b/addons/velaux/parameter.cue
@@ -13,7 +13,7 @@ parameter: {
 	secretName?: string
 	// +usage=Specify the gateway type.
 	gatewayDriver: *"nginx" | "traefik"
-	// +usage=Set ingress class name in 'kubernetes.io/ingress.class' annotation.
+	// +usage=Specify the ingress class name if gateway driver is nginx.
 	class: *"nginx" | string
 	// +usage=Specify the serviceAccountName for apiserver
 	serviceAccountName: *"kubevela-ux" | string

--- a/addons/velaux/resources/server.cue
+++ b/addons/velaux/resources/server.cue
@@ -23,7 +23,7 @@ _nginxTrait: *[
 				http: {
 					"/": 8000
 				}
-				class: "nginx"
+				class: parameter["class"]
 			}
 		}
 	},

--- a/addons/velaux/schemas/addon-uischema-velaux.yaml
+++ b/addons/velaux/schemas/addon-uischema-velaux.yaml
@@ -35,5 +35,3 @@
   sort: 11
 - jsonKey: imagePullSecrets
   sort: 13
-- jsonKey: class
-  sort: 14

--- a/addons/velaux/schemas/addon-uischema-velaux.yaml
+++ b/addons/velaux/schemas/addon-uischema-velaux.yaml
@@ -35,3 +35,5 @@
   sort: 11
 - jsonKey: imagePullSecrets
   sort: 13
+- jsonKey: class
+  sort: 14


### PR DESCRIPTION
### Description of your changes

Fixes #https://github.com/kubevela/catalog/issues/739


### How has this code been tested?
Tested by enabling the addon on a cluster with multiple nginx's and confirmed the ingress was correctly created and UX running
`vela addon enable velaux/ domain=<mydomain> gatewayDriver=nginx class=<myclassname>`

### Checklist

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [x] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [ ] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

If this pr wants to promote an experimental addon to verified, you must check whether meet these conditions too:
  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.
  - This addon must have some basic but necessary information.
    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).