### PR TITLE
[Addon] add cronjob support to azure-keyvault-csi trait

### DIFF
--- a/experimental/addons/azure-keyvault-csi/definitions/azure-keyvault-csi.cue
+++ b/experimental/addons/azure-keyvault-csi/definitions/azure-keyvault-csi.cue
@@ -8,7 +8,7 @@ import "strings"
     labels: {}
     description: "Add filesystem-mounted values from Azure KeyVault, using Azure key vault provider for secrets store csi driver which must be installed separately, see https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/getting-started/installation/"
     attributes: {
-        appliesToWorkloads: ["deployments.apps"]
+        appliesToWorkloads: ["deployments.apps","cronjobs.batch"]
         podDisruptive: true
     }
 }
@@ -26,7 +26,7 @@ template: {
 
     kvObjectsString: "array:\n- |\n" + strings.Join(kvObjects,"\n- |\n")
 
-    patch: spec: template: spec: {
+    let patchContent=template: spec: {
         // +patchKey=name
         volumes: [{
           name: "secrets-store",
@@ -46,6 +46,15 @@ template: {
             readOnly: true
           },]
         },]
+    }
+
+    patch: {
+        if context.output.spec.template != _|_ {
+            spec: patchContent
+        }
+        if context.output.spec.jobTemplate != _|_ {
+            spec: jobTemplate: spec: template: patchContent
+        }
     }
 
     outputs: {

--- a/experimental/addons/azure-keyvault-csi/metadata.yaml
+++ b/experimental/addons/azure-keyvault-csi/metadata.yaml
@@ -1,5 +1,5 @@
 name: azure-keyvault-csi
-version: 0.0.3
+version: 0.0.4
 system:
   vela: ">=v1.6.0"
 description: Trait providing access to Azure Keyvault values via csi driver


### PR DESCRIPTION
### Description of your changes

An update to the experimental azure-keyvault-csi trait (of which I am the author), so that it also supports being used with `cronjobs.batch` object/`cron-task` component.

### How has this code been tested?

Used in my own cluster

### Checklist

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [x] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples). - _none required_
- [x] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.
