### PR TITLE
[Addon] Datadog trait

### DIFF
--- a/experimental/addons/datadog/README.md
+++ b/experimental/addons/datadog/README.md
@@ -1,0 +1,31 @@
+
+# Datadog Trait
+
+Sets up the annotations and environment variables to assist a webservice 
+component to have correct collection of logs and apm stats by a datadog agent
+installed on the host nodes.
+
+The Datadog agent must already be install on the cluster nodes.
+
+## Use case example
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: myapp
+spec:
+  components:
+  - name: myapp
+    type: webservice
+    properties:
+      image: me/myapp:latest
+    traits:
+      - type: datadog
+        properties:
+          serviceName: myService
+          env:         prod
+          version:     1.0.15
+          source:      csharp
+```
+

--- a/experimental/addons/datadog/definitions/datadog.cue
+++ b/experimental/addons/datadog/definitions/datadog.cue
@@ -1,0 +1,94 @@
+import "strings"
+
+"datadog": {
+    type: "trait"
+    annotations: {}
+    labels: {}
+    description: "Add required env vars, annotations and host volume mount for datadog instrumentation"
+    attributes: {
+        appliesToWorkloads: ["deployments.apps","cronjobs.batch]
+        podDisruptive: true
+    }
+}
+
+template: {
+    let envVars=[
+	{ 
+            name: "DD_SERVICE"
+            value: parameter.serviceName
+        },
+	{ 
+            name: "DD_ENV"
+            value: parameter.env
+        },
+	{ 
+            name: "DD_VERSION"
+            value: parameter.version
+        },
+    ]
+
+    let volumeMount={
+        name: datadog
+        mountPath: path: parameter.mountPath
+    }
+
+    let volume = {
+        name: datadog
+        hostPath: path: parameter.hostMountPath
+    }
+
+    let patchContent= {
+        spec: {
+            containers: [
+                // +patchKey=name
+                env: envVars
+                // +patchKey=name
+                volumeMounts: [volumeMount]
+            ]
+            // +patchKey=name
+            volumes: [volume]
+        }
+        if parameter.source != _|_ {
+            metadata: annotations: [{
+                "ad.datadoghq.com/"+parameter.serviceName+".logs": "[{\"source\": \""+parameter.source+"\"}]"
+            }]
+        }
+    }
+    
+    patch: spec: {
+        if context.output.spec.template != _|_ {
+            template: patchContent
+        }
+        if context.output.spec.jobTemplate != _|_ {
+            if parameter.source != _|_ {
+                metadata: annotations: [{
+                    "ad.datadoghq.com/"+parameter.serviceName+".logs": "[{\"source\": \""+parameter.source+"\"}]"
+                }]
+            }
+            jobTemplate: {
+                spec: template: patchContent
+            }
+        }
+    }
+
+    parameter: {
+      // +usage=DD service name
+      serviceName:	string
+
+      // +usage=DD environment
+      env:		string
+
+      // +usage=DD version
+      version:		string
+
+      // +usage=mount path in container (default /var/run/datadog)
+      mountPath: *"/var/run/datadog" | string
+
+      // +usage=mount path on host (default /var/run/datadog)
+      hostMountPath: *"/var/run/datadog" | string
+
+      // +usage=source for logging (add as an annotation  ad.datadoghq.com/<serviceName>.logs: [{"source":"<this value>"}]
+      source?: string
+    }
+
+}

--- a/experimental/addons/datadog/metadata.yaml
+++ b/experimental/addons/datadog/metadata.yaml
@@ -1,0 +1,11 @@
+name: datadog
+version: 0.0.1
+system:
+  vela: ">=v1.9.0"
+description: Sets up the annotations and environment variables to assist a webservice or cron-tasks component to have correct collection of logs and apm stats by a datadog agent installed on the host nodes.
+url: 
+
+tags:
+  - alpha
+  - datadog
+

--- a/experimental/addons/datadog/template.yaml
+++ b/experimental/addons/datadog/template.yaml
@@ -1,0 +1,6 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: datadog
+  namespace: vela-system
+spec:


### PR DESCRIPTION
Adding a trait to sets up the annotations and environment variables to assist a webservice 
or cron-task component to have correct collection of logs and apm stats by a datadog agent
installed on the host nodes.

### Description of your changes

Add datadog experimental trait

### How has this code been tested?

Used on my own cluster.

### Checklist

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [x] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

Doc update not yet performed.  I'm happy to do that before PR merged, but need some assistance - The PR template mentions kubevela.io, but is it now kubevela.github.io? I also can't really figure out how the source maps to the published site. Happy to raise a PR for docs too, but I'm going to need some pointers.
