### PR TITLE
[Addon] fix azure-keyvault-csi trait

### DIFF
--- a/experimental/addons/azure-keyvault-csi/definitions/azure-keyvault-csi.cue
+++ b/experimental/addons/azure-keyvault-csi/definitions/azure-keyvault-csi.cue
@@ -26,26 +26,28 @@ template: {
 
     kvObjectsString: "array:\n- |\n" + strings.Join(kvObjects,"\n- |\n")
 
-    let patchContent=template: spec: {
-        // +patchKey=name
-        volumes: [{
-          name: "secrets-store",
-          csi: {
-            driver: "secrets-store.csi.k8s.io",
-            readOnly: true,
-            volumeAttributes: {
-              secretProviderClass: context.name
-            }
-          }
-        },]
-        containers: [{
-          // +patchKey=name
-          volumeMounts: [{
-            mountPath: "/mnt/secrets-store",
-            name: "secrets-store",
-            readOnly: true
-          },]
-        },]
+    let patchContent={
+        spec: {
+            // +patchKey=name
+            volumes: [{
+              name: "secrets-store",
+              csi: {
+                driver: "secrets-store.csi.k8s.io",
+                readOnly: true,
+                volumeAttributes: {
+                  secretProviderClass: context.name
+                }
+              }
+            },]
+            containers: [{
+              // +patchKey=name
+              volumeMounts: [{
+                mountPath: "/mnt/secrets-store",
+                name: "secrets-store",
+                readOnly: true
+              },]
+            },]
+        }
     }
 
     patch: {

--- a/experimental/addons/azure-keyvault-csi/metadata.yaml
+++ b/experimental/addons/azure-keyvault-csi/metadata.yaml
@@ -1,5 +1,5 @@
 name: azure-keyvault-csi
-version: 0.0.4
+version: 0.0.5
 system:
   vela: ">=v1.6.0"
 description: Trait providing access to Azure Keyvault values via csi driver


### PR DESCRIPTION
### Description of your changes

Fixes a typo preventing the addon being enabled.

### How has this code been tested?

Used locally.

### Checklist

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [x] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.
