### PR TITLE
[Addon] fix: removing hardcoded non-existing flink operator helm chart, and allowing for parameterising operator version

### DIFF
--- a/addons/flink-kubernetes-operator/metadata.yaml
+++ b/addons/flink-kubernetes-operator/metadata.yaml
@@ -1,5 +1,5 @@
 name: flink-kubernetes-operator
-version: 1.3.2
+version: 1.4.0
 description: A Kubernetes operator for Apache Flink
 icon: https://flink.apache.org/img/logo/png/500/flink_squirrel_500.png
 url: https://github.com/apache/flink-kubernetes-operator

--- a/addons/flink-kubernetes-operator/parameter.cue
+++ b/addons/flink-kubernetes-operator/parameter.cue
@@ -1,16 +1,18 @@
 parameter: {
-        //+usage=Deploy to specified clusters. Leave empty to deploy to all clusters.
-        clusters?: [...string]
-        //+usage=Namespace to deploy to, defaults to flink-operator
-        namespace: *"flink-operator" | string
-        // +usage=Specify if create  the webhook or not
-        "createWebhook": *false | bool
-        // +usage=Specify the image repository
-        "imageRepository": *"apache/flink-kubernetes-operator" | string
-        // +usage=Specify the image tag
-        "imageTag": *"latest" | string
-        // +usage=Specify if create the sa for job or not
-        "createJobServiceAccount": *false|bool
-        //+usage=Specify if upgrade the CRDs when upgrading flink-kubernetes-operator or not
+	//+usage=Deploy to specified clusters. Leave empty to deploy to all clusters.
+	clusters?: [...string]
+	//+usage=Namespace to deploy to, defaults to flink-operator
+	namespace: *"flink-operator" | string
+	// +usage=Specify if create  the webhook or not
+	"createWebhook": *false | bool
+	// +usage=Specify the image repository
+	"imageRepository": *"apache/flink-kubernetes-operator" | string
+	// +usage=Specify the image tag
+	"imageTag": *"latest" | string
+	// +usage=Specify if create the sa for job or not
+	"createJobServiceAccount": *false | bool
+	//+usage=Specify if upgrade the CRDs when upgrading flink-kubernetes-operator or not
 	upgradeCRD: *false | bool
+	//+usage=Specify the flink operator version, defaults to 1.9.0
+	flinkOperatorVersion: *"1.9.0" | string
 }

--- a/addons/flink-kubernetes-operator/template.cue
+++ b/addons/flink-kubernetes-operator/template.cue
@@ -20,10 +20,10 @@ output: {
 				dependsOn: ["flink-operator-ns"]
 				properties: {
 					repoType:        "helm"
-					url:             "https://downloads.apache.org/flink/flink-kubernetes-operator-1.3.1/"
+					url:             "https://downloads.apache.org/flink/flink-kubernetes-operator-" + parameter["flinkOperatorVersion"] + "/"
 					chart:           "flink-kubernetes-operator"
 					targetNamespace: parameter["namespace"]
-					version:         "1.3.1"
+					version:         parameter["flinkOperatorVersion"]
 					upgradeCRD:      parameter.upgradeCRD
 					values: {
 						webhook: {


### PR DESCRIPTION
Hello Everyone 👋 Flink people seem to have removed old versions of the operator from their helm chart repository. The oldest version that is still in existence is 1.7.0. I've removed the hardcoded version reference, and allowed for parameterising the version going forward.

<!--
Thank you for contributing to KubeVela Addons!

A new addon added in this repo should be put in as an experimental one unless you have test for a long time in your product environment and be approved by most maintainers.

An experimental addon must meet some conditions to be promoted as a verified one.

-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. 
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

If this pr wants to promote an experimental addon to verified, you must check whether meet these conditions too:
  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.
  - This addon must have some basic but necessary information.
    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).