### PR TITLE
[Addon] Fix for datadog trait logging source setup 

### DIFF
--- a/experimental/addons/datadog/definitions/datadog.cue
+++ b/experimental/addons/datadog/definitions/datadog.cue
@@ -76,7 +76,7 @@ template: {
     let sourceAnnotation = {
         if parameter.source != _|_ {
             metadata: annotations: {
-                ("ad.datadoghq.com/"+parameter.serviceName+".logs"): "[{\"source\": \""+parameter.source+"\"}]"
+                ("ad.datadoghq.com/"+context.name+".logs"): "[{\"source\": \""+parameter.source+"\"}]"
             }
         }
     }
@@ -135,7 +135,7 @@ template: {
       // +usage=name of host mount volume (default datadog)
       volumeName: *"datadog" | string
 
-      // +usage=source for logging - added as an annotation 'ad.datadoghq.com/<serviceName>.logs: [{"source":"<this value>"}]', and if logDirectSubmissionIntegrations is given, also assigned to DD_LOGS_DIRECT_SUBMISSION_SOURCE env var.
+      // +usage=source for logging - added as an annotation 'ad.datadoghq.com/<component name>.logs: [{"source":"<this value>"}]', and if logDirectSubmissionIntegrations is given, also assigned to DD_LOGS_DIRECT_SUBMISSION_SOURCE env var.
       source?: string
 
       // +usage=auto-map standard dependencies to <serviceName>-dependency by setting DD_TRACE_SERVICE_MAPPING env var (default false)

--- a/experimental/addons/datadog/metadata.yaml
+++ b/experimental/addons/datadog/metadata.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.0.4
+version: 0.0.5
 system:
   vela: ">=v1.9.0"
 description: Sets up the annotations and environment variables to assist a webservice or cron-task component to have correct collection of logs and apm stats by a datadog agent installed on the host nodes.


### PR DESCRIPTION
… when serviceName differs from component name
### Description of your changes

This fixes the logging annotation added by this trait so that it uses the component name 
and not any serviceName alias specified.  This is to give correct operation of the 
logging source functionality.

### How has this code been tested?

Used on own cluster

### Checklist

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [x] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [x] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

(N/A - this addon to remain alpha)
