### PR TITLE
[Addon] Add Crossplane Azure Addon for provisioning Cloud Resources on Azure

### DIFF
--- a/examples/crossplane-azure/resourceGroup.yaml
+++ b/examples/crossplane-azure/resourceGroup.yaml
@@ -1,0 +1,11 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: crossplane-azure-rg-app
+spec:
+  components:
+    - name: resource-group
+      type: azure-rg
+      properties:
+        Name: crossplane-test-rg
+        Location: eastus # Refer to the Azure region names reference for a complete list: https://azuretracks.com/2021/04/current-azure-region-names-reference/

--- a/examples/crossplane-azure/storageAccount.yaml
+++ b/examples/crossplane-azure/storageAccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: crossplane-azure-storage-acct-app
+spec:
+  components:
+    - name: storage-account
+      type: azure-storage-account
+      properties:
+        Name: crossplanetestacct
+        ResourceGroupName: test-rg  # Ensure the Resource Group exists already in the Azure account.
+        Location: eastus   # Refer to the Azure region names reference for a complete list: https://azuretracks.com/2021/04/current-azure-region-names-reference/
+        SKU_Name: Standard_GRS
+        Kind: Storage
+        secretName: storageaccount-connection-secret

--- a/examples/crossplane-azure/virtualNetwork.yaml
+++ b/examples/crossplane-azure/virtualNetwork.yaml
@@ -1,0 +1,16 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: crossplane-azure-vnet-app
+spec:
+  components:
+    - name: virtual-network
+      type: azure-vnet
+      properties:
+        Name: crossplane-vnet
+        ResourceGroupName: crossplane-test-rg
+        Location: eastus # Refer to the Azure region names reference for a complete list: https://azuretracks.com/2021/04/current-azure-region-names-reference/
+        AddressPrefixes:
+          - "10.0.0.0/16"
+          - "192.168.0.0/16"
+          - "172.16.0.0/12"

--- a/experimental/addons/crossplane-azure/README.md
+++ b/experimental/addons/crossplane-azure/README.md
@@ -1,0 +1,201 @@
+# Crossplane Azure
+
+[Azure Provider](https://github.com/crossplane-contrib/provider-azure) for Crossplane.
+
+## What is this addon?
+
+The Crossplane Azure addon enables users to manage Azure cloud resources directly from their Kubernetes clusters using Crossplane. By integrating Azure capabilities into your Kubernetes environment, this addon facilitates seamless infrastructure management alongside your application workloads.
+
+## Why use this addon?
+
+This addon allows you to provision and manage various Azure resources using Kubernetes-native tooling. Use cases include:
+
+- **Infrastructure as Code (IaC)**: Define and manage your Azure resources declaratively using YAML files via KubeVela Applications.
+- **Unified Management**: Manage Azure resources in conjunction with other cloud providers and services from a single Kubernetes control plane.
+- **Enhanced Workflow**: Take advantage of KubeVela's features, such as application delivery, component composition, and resource management, to create an efficient workflow for your Azure cloud infrastructure.
+
+## How to use this addon?
+
+### Step 1: Install Azure CLI
+To interact with Azure resources, you need to have the Azure CLI installed. Follow the instructions in the official documentation to install the Azure CLI for your operating system: [Install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
+
+### Step 2: Login to Azure 
+Once you have the Azure CLI installed, log in to your Azure account using the following command in the terminal or in the command prompt:
+```shell
+az login
+```
+This command will open a web browser where you can enter your Azure credentials.
+
+### Step 3: Enable the addon
+To get started, enable the Crossplane Azure addon:
+
+```shell
+vela addon enable crossplane-azure
+```
+### Step 4: Authenticate Azure Provider for Crossplane
+
+Before provisioning Azure resources, you need to authenticate the Azure provider. 
+1) To retrieve current subscription ID of the Azure account via Azure CLI, run the following command in the terminal 
+```shell
+$ az account show --query id --output tsv
+```
+2) Use the following command to create a [Service Principal](https://devblogs.microsoft.com/devops/demystifying-service-principals-managed-identities/#service-principal) and obtain credentials:
+
+```shell
+$ az ad sp create-for-rbac  --json-auth true --role Owner --scopes="/subscriptions/<your-subscription-id>" -n "crossplane-sp-rbac" > "creds.json"
+```
+
+This command will generate a JSON file called `creds.json`, which contains the necessary credentials for the Crossplane Azure provider. The file will have the following structure:
+
+```json
+{
+  "clientId": "1111111-2222-3333-4444-555555555555",
+  "clientSecret": "xxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyy",
+  "tenantId": "33333333-4444-5555-6666-777777777777",
+  "subscriptionId": "22222222-3333-4444-5555-666666666666",
+  "activeDirectoryEndpointUrl": "https://login.microsoftonline.com/",
+  "resourceManagerEndpointUrl": "https://management.azure.com/",
+  "activeDirectoryGraphResourceId": "https://graph.windows.net/",
+  "sqlManagementEndpointUrl": "https://management.core.windows.net:8443/",
+  "galleryEndpointUrl": "https://gallery.azure.com/",
+  "managementEndpointUrl": "https://management.core.windows.net/"
+}
+```
+
+You will use these values in the application configuration below.
+
+### Step 5: Apply the Azure Provider configuration
+Create an application configuration to authenticate your Azure provider. Replace the placeholders with the values obtained from the previous step:
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: crossplane-azure-provider-config-app
+  namespace: vela-system
+spec:
+  components:
+    - name: azure
+      type: crossplane-azure
+      properties:
+        AZURE_APP_ID: <appId>
+        AZURE_PASSWORD: <password>
+        AZURE_TENANT_ID: <tenantId>
+        AZURE_SUBSCRIPTION_ID: <subscriptionId>
+        provider_name: azure-provider  # Defaults to "azure-provider". If you wish to override with any other name, you can specify it here. This name will be used in other configurations for referencing the Azure Crossplane ProviderConfig in the next steps.
+```
+
+### Step 6: Provision Azure Resources
+Now that your Azure provider is configured, you can start provisioning Azure resources. Let's create a [Resource Group](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal#what-is-a-resource-group), a [Virtual Network (VNet)](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview) and a [Storage Account](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview) as examples.
+
+#### a) Create a Resource Group
+Apply the KubeVela application below to create a Resource Group:
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: crossplane-azure-rg-app  # This name will be shown on the UI.
+spec:
+  components:
+    - name: resource-group
+      type: azure-rg
+      properties:
+        Name: crossplane-test-rg
+        Location: eastus # Refer to the Azure region names reference for a complete list: https://azuretracks.com/2021/04/current-azure-region-names-reference/
+        providerConfigName: azure-provider  # Use the name configured for Azure Crossplane provider at step 5.
+```
+
+#### b) Create a Virtual Network (VNet)
+Next, you can create a Virtual Network (VNet)  by applying the following KubeVela application configuration:
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: crossplane-azure-vnet-app # This name will be shown on the UI.
+spec:
+  components:
+    - name: virtual-network
+      type: azure-vnet
+      properties:
+        Name: crossplane-vnet
+        ResourceGroupName: crossplane-test-rg  # Ensure the Resource Group exists already in the Azure account.
+        Location: eastus # Refer to the Azure region names reference for a complete list: https://azuretracks.com/2021/04/current-azure-region-names-reference/
+        AddressPrefixes: # Specify the CIDR block for the Virtual Network.
+          - "10.0.0.0/16"  
+          - "192.168.0.0/16"
+          - "172.16.0.0/12"
+        providerConfigName: azure-provider  # Use the name configured for Azure Crossplane provider at step 5.
+```
+
+#### c) Creating a Storage Account 
+Next, you can create a Storage Account by applying the following application configuration. Before proceeding, ensure that your Azure subscription has the necessary resource providers registered to avoid potential errors. 
+
+If you are using a new Azure account, you may encounter the following error when attempting to create a Storage Account:
+
+```shell
+storage.AccountsClient#CheckNameAvailability: Failure responding to request: StatusCode=404
+```
+To prevent this error, you need to ensure that the `Microsoft.Storage` resource provider is registered in your Azure subscription. Follow these steps to register the resource provider:
+
+1. Navigate to your Azure Subscription in the Azure portal. 
+2. Select **Resource Providers** from the left pane. 
+3. Locate `Microsoft.Storage` in the list. 
+4. Click **Register**.
+
+![](https://learn-attachment.microsoft.com/api/attachments/f9b053d2-ebee-40cb-a59d-93420d028b7b?platform=QnA)
+Once the resource provider is registered, you can create the Storage Account without any issues. Below is the KubeVela application configuration to create the Storage Account:
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: crossplane-azure-storage-acct-app # This name will be shown on the UI.
+spec:
+  components:
+    - name: storage-account
+      type: azure-storage-account
+      properties:
+        Name: crossplanetestacct
+        ResourceGroupName: test-rg  # Ensure the Resource Group exists already in the Azure account.
+        Location: eastus   # Refer to the Azure region names reference for a complete list: https://azuretracks.com/2021/04/current-azure-region-names-reference/
+        SKU_Name: Standard_LRS # Valid SKUs: Standard_LRS, Standard_GRS, etc.
+        Kind: Storage
+        providerConfigName: azure-provider # Use the name configured at step 5.
+        secretName: storageaccount-connection-secret
+```
+
+### Step 7: Verify the Provisioned Resources
+Once the applications are running, you can check the status of your resources via the Vela CLI command shown below:
+```shell
+$ vela ls
+
+
+APP                                     COMPONENT       TYPE                    TRAITS  PHASE   HEALTHY STATUS  CREATED-TIME                                       
+crossplane-azure-rg-app                 resource-group  azure-rg                        running healthy         2024-10-17 09:44:51 +0000 UTC
+crossplane-azure-vnet-app               virtual-network azure-vnet                      running healthy         2024-10-17 09:45:33 +0000 UTC
+crossplane-azure-storage-acct-app       storage-account azure-storage-account           running healthy         2024-10-17 09:45:48 +0000 UTC
+```
+
+You can use the [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/reference-docs-index) commands in your terminal to verify the resources:
+```shell
+$ az group show --name <your-resource-group-name>
+$ az network vnet show --resource-group <your-resource-group-name> --name <your-vnet-name>
+$ az storage account show --resource-group <your-resource-group-name> --name <your-storage-account-name>
+```
+
+You can also verify them in the Azure portal, alongside the Azure CLI commands:
+
+![](https://i.ibb.co/fNCGtcr/image.png)
+The image above shows that the Resource Group `crossplane-test-rg` has been successfully created from KubeVela via Crossplane.
+
+![](https://i.ibb.co/FJs5WY4/image.png)
+The image above confirms that the Virtual Network `crossplane-vnet` was created in the `eastus` region within the `test-rg` Resource Group, which was already created in the portal.
+
+![](https://i.ibb.co/ry8PKqW/image.png)
+The image above confirms that the Virtual Network contains three address spaces, as specified in the application configuration.
+
+![](https://i.ibb.co/nQ1n6VV/image.png)
+The image above confirms that the Storage Account `crossplanetestacct` was successfully created in the `test-rg` Resource Group,  which was already created in the portal.
+

--- a/experimental/addons/crossplane-azure/definitions/azure-rg.cue
+++ b/experimental/addons/crossplane-azure/definitions/azure-rg.cue
@@ -1,0 +1,33 @@
+"azure-rg": {
+	type:        "component"
+	description: "Azure Resource Group"
+	attributes: workload: type: "autodetects.core.oam.dev"
+}
+
+template: {
+	output: {
+		apiVersion: "azure.crossplane.io/v1alpha3"
+		kind:       "ResourceGroup"
+		metadata:
+			name: parameter.Name
+
+		spec: {
+			location: parameter.Location
+
+			providerConfigRef: {
+				name: parameter.providerConfigName
+			}
+		}
+	}
+
+	parameter: {
+		// +usage=Specify the Resource Group name
+		Name: string
+
+		// +usage=Specify the location where the Resource Group will be created. Examples: "eastus", "centralindia", etc. Refer: https://azuretracks.com/2021/04/current-azure-region-names-reference/ for the Azure region names reference.
+		Location: string
+
+		// +usage=The name of the Azure ProviderConfig to use. This should match the provider you configured for Azure, defaults to `azure-provider`
+		providerConfigName: *"azure-provider" | string
+	}
+}

--- a/experimental/addons/crossplane-azure/definitions/azure-storage-account.cue
+++ b/experimental/addons/crossplane-azure/definitions/azure-storage-account.cue
@@ -1,0 +1,60 @@
+"azure-storage-account": {
+	type:        "component"
+	description: "Azure Storage Account"
+	attributes: workload: type: "autodetects.core.oam.dev"
+}
+
+template: {
+	output: {
+		apiVersion: "storage.azure.crossplane.io/v1alpha3"
+		kind:       "Account"
+		metadata:
+			name: parameter.Name
+		spec: {
+			resourceGroupName: parameter.ResourceGroupName
+
+			storageAccountSpec: {
+				kind: parameter.Kind
+				location: parameter.Location
+
+				sku: {
+					name: parameter.SKU_Name
+				}
+			}
+
+			if parameter.secretName != _|_ {
+				writeConnectionSecretToRef: {
+					namespace: context.namespace
+					name:      parameter.secretName
+				}
+			}
+
+			providerConfigRef: {
+				name: parameter.providerConfigName
+			}
+		}
+	}
+
+	parameter: {
+		// +usage=Specify the name of the Storage Account. Ensure it's less than 24 characters.
+		Name:  string
+
+		// +usage=The name of the Resource Group where the Storage Account will be created.
+		ResourceGroupName: string
+
+		// +usage=The kind of Storage Account to create. Possible values: "Storage", "BlobStorage".
+		Kind: *"Storage" | "BlobStorage" | string
+
+		// +usage=Location where the Storage Account will be created (e.g., "East US", "West US").
+		Location: string
+
+		// +usage=The SKU of the Storage Account. Valid values: "Standard_LRS", "Standard_GRS", "Standard_RAGRS", "Standard_ZRS", "Premium_LRS".
+		SKU_Name: *"Standard_LRS" | "Standard_GRS" | "Standard_RAGRS" | "Standard_ZRS" | "Premium_LRS" | string
+
+		// +usage=The name of the Azure ProviderConfig to use. This should match the provider you configured for Azure, defaults to `azure-provider`
+		providerConfigName: *"azure-provider" | string
+
+		// +usage=Optional secret name to store the connection details of the Storage Account.
+		secretName?: string
+	}
+}

--- a/experimental/addons/crossplane-azure/definitions/azure-vnet.cue
+++ b/experimental/addons/crossplane-azure/definitions/azure-vnet.cue
@@ -1,0 +1,46 @@
+"azure-vnet": {
+    type:        "component"
+    description: "Azure Virtual Network"
+    attributes: workload: type: "autodetects.core.oam.dev"
+}
+
+template: {
+    output: {
+        apiVersion: "network.azure.crossplane.io/v1alpha3"
+        kind:       "VirtualNetwork"
+        metadata: {
+            name: parameter.Name
+        }
+        spec: {
+            resourceGroupName:  parameter.ResourceGroupName
+            location: parameter.Location
+
+            properties: {
+                addressSpace: {
+                    addressPrefixes: parameter.AddressPrefixes
+                }
+            }
+
+            providerConfigRef: {
+                name: parameter.providerConfigName
+            }
+        }
+    }
+
+    parameter: {
+        // +usage=Specify the name of the Virtual Network.
+        Name: string
+
+        // +usage=Specify the name of the Resource Group. Ensure that it exists already in the Azure Account.
+        ResourceGroupName: string
+
+        // +usage=Specify the location/region where you want your Virtual Network to be created. Examples: "eastus", "centralindia", etc. Refer: https://azuretracks.com/2021/04/current-azure-region-names-reference/ for the Azure region names reference.
+        Location: string
+
+        // +usage=Specify the address space for the Virtual Network. This defines the range of IP addresses your network can use. You can provide more than one address space if needed. Example: ["10.0.0.0/16", "10.1.0.0/16"].
+        AddressPrefixes: [...string]
+
+				// +usage=The name of the Azure ProviderConfig to use. This should match the provider you configured for Azure, defaults to `azure-provider`
+        providerConfigName: *"azure-provider" | string
+    }
+}

--- a/experimental/addons/crossplane-azure/definitions/crossplane-azure.cue
+++ b/experimental/addons/crossplane-azure/definitions/crossplane-azure.cue
@@ -1,0 +1,91 @@
+import "encoding/json"
+
+"crossplane-azure": {
+  type:        "component"
+  description: "Azure Provider for Crossplane"
+  attributes: workload: type: "autodetects.core.oam.dev"
+}
+
+template: {
+  output: {
+    apiVersion: "azure.crossplane.io/v1beta1"
+    kind:       "ProviderConfig"
+    metadata: {
+      name: parameter.provider_name
+    }
+    spec: {
+      credentials: {
+        source: "Secret"
+        secretRef: {
+          namespace: "vela-system"
+          name:      parameter.provider_name + "-account-creds-crossplane"
+          key:       "creds"
+        }
+      }
+    }
+  }
+
+  outputs: {
+    "credential": {
+      apiVersion: "v1"
+      kind:       "Secret"
+      metadata: {
+        name:      parameter.provider_name + "-account-creds-crossplane"
+        namespace: "vela-system"
+      }
+      type: "Opaque"
+      stringData: {
+        creds: json.Marshal({
+          clientId:     parameter.AZURE_APP_ID
+          clientSecret: parameter.AZURE_PASSWORD
+          tenantId:     parameter.AZURE_TENANT_ID
+          subscriptionId: parameter.AZURE_SUBSCRIPTION_ID
+          activeDirectoryEndpointUrl: parameter.AZURE_AD_ENDPOINT
+					resourceManagerEndpointUrl: parameter.AZURE_RESOURCE_MANAGER_ENDPOINT
+          activeDirectoryGraphResourceId: parameter.AZURE_AD_GRAPH_RESOURCE
+          sqlManagementEndpointUrl: parameter.AZURE_SQL_MANAGEMENT_ENDPOINT
+          galleryEndpointUrl: parameter.AZURE_GALLERY_ENDPOINT
+          managementEndpointUrl: parameter.AZURE_MANAGEMENT_ENDPOINT
+        })
+      }
+    }
+  }
+
+  parameter: {
+    //+usage=The name of Crossplane Provider for Azure. Specify a unique name, defaults to `azure-provider`
+    provider_name: *"azure-provider" | string
+
+    //+usage=Run the following Azure CLI command to create a service principal and get the required values:
+		// az ad sp create-for-rbac --sdk-auth --role Owner --scopes="/subscriptions/<your-subscription-id>" -n "crossplane-sp-rbac" > "creds.json"
+		// Use the `clientId`, `clientSecret`, `tenantId`, and `subscriptionId` from the `creds.json` file as parameters for the Crossplane Azure provider.
+
+    AZURE_APP_ID: string
+
+    //+usage=The `password` field from the CLI output corresponds to `AZURE_PASSWORD`.
+    AZURE_PASSWORD: string
+
+    //+usage=The `tenant` field from the CLI output corresponds to `AZURE_TENANT_ID`.
+    AZURE_TENANT_ID: string
+
+    //+usage= The `subscriptionId` from the CLI output corresponds to `AZURE_SUBSCRIPTION_ID`.
+    AZURE_SUBSCRIPTION_ID: string
+
+    //+usage=The `activeDirectoryEndpointUrl` field, defaults to Azure public cloud.
+    AZURE_AD_ENDPOINT: *"https://login.microsoftonline.com/" | string
+
+    //+usage=The `resourceManagerEndpointUrl`, defaults to Azure public cloud.
+    AZURE_RESOURCE_MANAGER_ENDPOINT: *"https://management.azure.com/" | string
+
+    //+usage=The `activeDirectoryGraphResourceId`, defaults to Azure public cloud.
+    AZURE_AD_GRAPH_RESOURCE: *"https://graph.windows.net/" | string
+
+    //+usage=The `sqlManagementEndpointUrl`, defaults to Azure public cloud.
+    AZURE_SQL_MANAGEMENT_ENDPOINT: *"https://management.core.windows.net:8443/" | string
+
+    //+usage=The `galleryEndpointUrl`, defaults to Azure public cloud.
+    AZURE_GALLERY_ENDPOINT: *"https://gallery.azure.com/" | string
+
+    //+usage=The `managementEndpointUrl`, defaults to Azure public cloud.
+    AZURE_MANAGEMENT_ENDPOINT: *"https://management.core.windows.net/" | string
+  }
+}

--- a/experimental/addons/crossplane-azure/metadata.yaml
+++ b/experimental/addons/crossplane-azure/metadata.yaml
@@ -1,0 +1,18 @@
+name: crossplane-azure
+version: 0.0.1
+description: Azure Provider for Crossplane, enabling Azure resource management directly from KubeVela.
+icon: https://www.vaisulweb.com/wp-content/uploads/2019/02/azure_logo_794_new.png
+url: https://crossplane.io/
+
+tags:
+  - Crossplane provider
+  - Azure
+
+deployTo:
+  control_plane: true
+  runtime_cluster: false
+
+dependencies:
+- name: crossplane
+
+invisible: false

--- a/experimental/addons/crossplane-azure/resources/provider.yaml
+++ b/experimental/addons/crossplane-azure/resources/provider.yaml
@@ -1,0 +1,9 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-azure
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-azure:v0.20.1
+  packagePullPolicy: IfNotPresent
+  revisionActivationPolicy: Automatic
+  revisionHistoryLimit: 1

--- a/experimental/addons/crossplane-azure/template.yaml
+++ b/experimental/addons/crossplane-azure/template.yaml
@@ -1,0 +1,5 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: crossplane-azure-app
+  namespace: vela-system

--- a/test/e2e-test/hack/addon-vela-test.sh
+++ b/test/e2e-test/hack/addon-vela-test.sh
@@ -65,6 +65,9 @@ vela addon disable istio
 vela addon enable experimental/addons/dapr
 vela addon disable dapr
 
+# crossplane-azure
+vela addon enable experimental/addons/crossplane-azure
+vela addon disable crossplane-azure
 
 ## test dependencies-addon unInstall
 for i in $(seq 1 1 5)


### PR DESCRIPTION
### Title
[Addon] Add Crossplane-Azure Addon

### Description of your changes

This PR adds the **Crossplane-Azure** addon to the KubeVela catalog as an experimental addon. The addon facilitates the provisioning of Azure resources like Resource Groups, Virtual Networks, and Storage Accounts via Crossplane on KubeVela.

- It contains necessary components, including CUE files and provider configurations, as well as a detailed `README.md` file explaining the usage, installation, and authentication setup. 
- Additionally, examples are provided in the `examples` directory, showing the Azure Resource Group, Virtual Network, and Storage Account creation.

### How has this code been tested?

I have copied the entire addon directory `crossplane-azure`, which contains the CUE files and provider files. I tested this locally by using the following command:

```bash
vela addon enable ./<the-directory-path>
```
After enabling the addon, I verified the resource provisioning in my Azure portal. The expected resources (Resource Group, Virtual Network, and Storage Account) were successfully created. 

### Checklist

I have:

- [✔] Title of the PR starts with type (e.g. `[Addon]`, `[example]`, or `[Doc]`).
- [✔] Updated/Added relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [✔] Placed the new addon in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [✔] Updated the addon version in `metadata.yaml`.

### Request for Reviewers

Dear Maintainers,

This PR introduces the **Crossplane-Azure** addon for provisioning Azure resources (Resource Groups, VNETs, Storage Accounts) via Crossplane in KubeVela. I kindly request that this addon (Crossplane-Azure), along with the **[Crossplane](https://github.com/kubevela/catalog/tree/master/experimental/addons/crossplane)** and **[Crossplane-AWS](https://github.com/kubevela/catalog/tree/master/experimental/addons/crossplane-aws)** addons (currently in experimental), be promoted to public. This would enable users to manage cloud resources more efficiently across Azure and AWS using Kubevela.

**In future updates, I plan to add more CUE files for Azure resources to expand its provisioning capabilities from KubeVela. I will include the proper CUE files using the Azure CRDs for Crossplane (refering [Azure CRDs for Crossplane](https://doc.crds.dev/github.com/crossplane/provider-azure)).**



