### PR TITLE
[Addon] add statefulset to datadog and keyvault

### DIFF
--- a/experimental/addons/azure-keyvault-csi/definitions/azure-keyvault-csi.cue
+++ b/experimental/addons/azure-keyvault-csi/definitions/azure-keyvault-csi.cue
@@ -8,7 +8,7 @@ import "strings"
     labels: {}
     description: "Add filesystem-mounted values from Azure KeyVault, using Azure key vault provider for secrets store csi driver which must be installed separately, see https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/getting-started/installation/"
     attributes: {
-        appliesToWorkloads: ["deployments.apps","cronjobs.batch"]
+        appliesToWorkloads: ["deployments.apps","cronjobs.batch","statefulsets.apps"]
         podDisruptive: true
     }
 }

--- a/experimental/addons/azure-keyvault-csi/metadata.yaml
+++ b/experimental/addons/azure-keyvault-csi/metadata.yaml
@@ -1,5 +1,5 @@
 name: azure-keyvault-csi
-version: 0.0.6
+version: 0.0.7
 system:
   vela: ">=v1.6.0"
 description: Trait providing access to Azure Keyvault values via csi driver

--- a/experimental/addons/datadog/definitions/datadog.cue
+++ b/experimental/addons/datadog/definitions/datadog.cue
@@ -6,7 +6,7 @@ import "strings"
     labels: {}
     description: "Add required env vars, annotations and host volume mount for datadog instrumentation"
     attributes: {
-        appliesToWorkloads: ["deployments.apps","cronjobs.batch"]
+        appliesToWorkloads: ["deployments.apps","cronjobs.batch","statefulsets.apps"]
         podDisruptive: true
     }
 }

--- a/experimental/addons/datadog/metadata.yaml
+++ b/experimental/addons/datadog/metadata.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.0.5
+version: 0.0.6
 system:
   vela: ">=v1.9.0"
 description: Sets up the annotations and environment variables to assist a webservice or cron-task component to have correct collection of logs and apm stats by a datadog agent installed on the host nodes.


### PR DESCRIPTION
<!--
Thank you for contributing to KubeVela Addons!

A new addon added in this repo should be put in as an experimental one unless you have test for a long time in your product environment and be approved by most maintainers.

An experimental addon must meet some conditions to be promoted as a verified one.

-->

### Description of your changes
Added support for statefulset on the datadog and keyvault csi driver by updating the "appliesToWorkloads" field.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
tested locally with the "vela dry-run -d kubevela -f statefulset-app.yml --offline" The output yaml file had a statefulset definition with the information from datadog and kv csi driver traits.


<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. 
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [x] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

If this pr wants to promote an experimental addon to verified, you must check whether meet these conditions too:
  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.
  - This addon must have some basic but necessary information.
    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).