### PR TITLE
[Addon]: added group in vela-core-shard-manager addon yaml

### DIFF
--- a/addons/vela-core-shard-manager/metadata.yaml
+++ b/addons/vela-core-shard-manager/metadata.yaml
@@ -1,5 +1,5 @@
 name: vela-core-shard-manager
-version: v0.1.1
+version: v0.1.2
 description: "The manager for vela-core."
 icon: "https://static.kubevela.net/images/logos/KubeVela%20-03.png"
 url: "https://github.com/kubevela/kubevela"

--- a/addons/vela-core-shard-manager/template.cue
+++ b/addons/vela-core-shard-manager/template.cue
@@ -22,7 +22,7 @@ output: {
 				type: "ref-objects"
 				name: "\(parameter.deploymentName)-\(key)"
 				properties: objects: [{
-					group: "apps"
+					group:    "apps"
 					resource: "deployments"
 					name:     parameter.deploymentName
 				}]

--- a/addons/vela-core-shard-manager/template.cue
+++ b/addons/vela-core-shard-manager/template.cue
@@ -22,6 +22,7 @@ output: {
 				type: "ref-objects"
 				name: "\(parameter.deploymentName)-\(key)"
 				properties: objects: [{
+					group: "apps"
 					resource: "deployments"
 					name:     parameter.deploymentName
 				}]


### PR DESCRIPTION
<!--
Thank you for contributing to KubeVela Addons!

A new addon added in this repo should be put in as an experimental one unless you have test for a long time in your product environment and be approved by most maintainers.

An experimental addon must meet some conditions to be promoted as a verified one.

-->

### Description of your changes
In KubeVela v1.10, the package [k8s.io/apimachinery](http://k8s.io/apimachinery) was upgraded from v0.26.3 to v0.29.2. We've observed that this upgrade causes KubeVela to only load the default groups ("[core.oam.dev](http://core.oam.dev/)" and "").
As a result, when using resources in ref-objects with a group other than the default, we now need to explicitly specify the group in the YAML. Specifically, we noticed that the vela-core-shard-manager add-on deployment is failing because the group needs to be specified. In this case, the apps group should be explicitly added for the deployment resource.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
Fixes #6719


### How has this code been tested?
We added the group in resource of the addon application and verified it deployed successfully.
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. 
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

If this pr wants to promote an experimental addon to verified, you must check whether meet these conditions too:
  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.
  - This addon must have some basic but necessary information.
    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).