### PR TITLE
Chore: Update the vela-workflow addon version to v0.6.2

### DIFF
--- a/addons/vela-workflow/metadata.yaml
+++ b/addons/vela-workflow/metadata.yaml
@@ -1,5 +1,5 @@
 name: vela-workflow
-version: v0.6.2
+version: v0.6.3
 description: "vela-workflow provides the capability to run a standalone workflow"
 icon: "https://static.kubevela.net/images/logos/KubeVela%20-03.png"
 url: "https://github.com/kubevela/workflow"

--- a/addons/vela-workflow/parameter.cue
+++ b/addons/vela-workflow/parameter.cue
@@ -9,7 +9,7 @@ const: {
 
 parameter: {
 	image:                *"oamdev/vela-workflow" | string
-	version:              *"0.6.0" | string
+	version:              *"0.6.2" | string
 	imagePullPolicy:      *"IfNotPresent" | "Never" | "Always"
 	concurrentReconciles: *4 | int
 	kubeQPS:              *50 | int


### PR DESCRIPTION
### Description of your changes

Changing the vela-workflow addon version to use v0.6.2 by default

I have:

- [ ] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [ ] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

If this pr wants to promote an experimental addon to verified, you must check whether meet these conditions too:
  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.
  - This addon must have some basic but necessary information.
    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Updated the default vela-workflow addon version to v0.6.2.

<!-- End of auto-generated description by mrge. -->

