### PR TITLE
[Addon] velaux: environment variables support

### DIFF
--- a/addons/velaux/metadata.yaml
+++ b/addons/velaux/metadata.yaml
@@ -1,5 +1,5 @@
 name: velaux
-version: v1.9.4
+version: v1.9.5
 description: KubeVela User Experience (UX). An extensible, application-oriented delivery and management Platform.
 icon: https://static.kubevela.net/images/logos/KubeVela%20-03.png
 url: https://kubevela.io

--- a/addons/velaux/parameter.cue
+++ b/addons/velaux/parameter.cue
@@ -27,15 +27,15 @@ parameter: {
 	enableImpersonation: true | *false
 	// +usage=Environment variables for velaux server.
 	env?: [...{
-		name: string
+		name:   string
 		value?: string
 		valueFrom?: {
 			configMapKeyRef?: {
-				key: string
+				key:  string
 				name: string
 			}
 			secretKeyRef?: {
-				key: string
+				key:  string
 				name: string
 			}
 		}

--- a/addons/velaux/parameter.cue
+++ b/addons/velaux/parameter.cue
@@ -25,4 +25,19 @@ parameter: {
 	nodePort: *30000 | int
 	// +usage=Enable impersonation means impersonating the login user to request the KubeAPI.
 	enableImpersonation: true | *false
+	// +usage=Environment variables for velaux server.
+	env?: [...{
+		name: string
+		value?: string
+		valueFrom?: {
+			configMapKeyRef?: {
+				key: string
+				name: string
+			}
+			secretKeyRef?: {
+				key: string
+				name: string
+			}
+		}
+	}]
 }

--- a/addons/velaux/resources/server.cue
+++ b/addons/velaux/resources/server.cue
@@ -82,6 +82,10 @@ server: {
 				}
 			},
 		]
+
+		if parameter.env != _|_ {
+			env: parameter.env
+		}
 	}
 	dependsOn: ["velaux-additional-privileges"]
 	traits: [


### PR DESCRIPTION
<!--
Thank you for contributing to KubeVela Addons!

A new addon added in this repo should be put in as an experimental one unless you have test for a long time in your product environment and be approved by most maintainers.

An experimental addon must meet some conditions to be promoted as a verified one.

-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Adding environment variables support to velaux addon, using partial coverage of Kubernetes pod spec's EnvVar.

The only way to set database connection in velaux addon is via `parameter.dbURL`, in plain text.

Because `parameter.dbURL` will be passed as part of `cmd` in Kubernetes pod spec, it can use variable substitutions `$(VAR)`. Those variables can refer to separately managed resources (secrets and/or config map). By allowing environment variables to be set, we can avoid putting sensitive information in `parameter.dbURL`.

Bumped version to 1.9.5. There happen to be a 1.9.5 in velaux releases.

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

On kubevela core version 1.10.6

Tested by enabling the addon without `env` parameter (existing capability), and upgrading with `env`:

```
vela addon upgrade ./addons/velaux \
  --override-definitions \
  dbType=postgres \
  dbURL=postgresql://user:$(DB_PASSWORD)@my.db.host:5432/mydb \
  env[0].name=DB_PASSWORD \
  env[0].valueFrom.secretKeyRef.name=my-externally-managed-secret \
  env[0].valueFrom.secretKeyRef.key=dbpassword
```

### Checklist

<!--
Please run through the below readiness checklist. 
-->

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [ ] Updated/Added any relevant [documentation](https://kubevela.io/docs/reference/addons/overview) and [examples](https://github.com/kubevela/catalog/tree/master/examples).
- [x] New addon should be put in [experimental](https://github.com/kubevela/catalog/tree/master/experimental/addons).
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

####  Verified Addon promotion rules

If this pr wants to promote an experimental addon to verified, you must check whether meet these conditions too:
  - [ ] This addon must be tested by addon's [e2e-test](./test/e2e-test/addon-test) to guarantee this addon can be enabled successfully.
  - This addon must have some basic but necessary information.
    - [ ] An accessible icon url and source url defined in addon's `metadata.yaml`.
    - [ ] A detail introduction include a basic example about how to use and what's the benefit of this addon in `README.md`.
    - [ ] Also provide an introduction in KubeVela [documentation](https://kubevela.net/docs/reference/addons/overview).
    - [ ] It's more likely to be accepted if useful examples provided in example [dir](examples/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add env[] support to the velaux addon so you can inject ConfigMap/Secret-based environment variables into the server pod. This enables $(VAR) substitution in dbURL to avoid hardcoded credentials.

- **New Features**
  - Added parameter.env[] with name, value, and valueFrom.{configMapKeyRef, secretKeyRef}.
  - server.cue passes env to the container when provided.

- **Migration**
  - No breaking changes.
  - Optionally set env vars and reference them in dbURL with $(VAR) to keep credentials out of plain text.

<sup>Written for commit 4f9c01d765bfb696a7acb0ff5214a63beb73b05b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



