### PR TITLE
[Addon] migrate cloudshell to native helmchart

### DIFF
--- a/addons/cloudshell/metadata.yaml
+++ b/addons/cloudshell/metadata.yaml
@@ -1,14 +1,11 @@
 name: cloudshell
-version: 0.0.10
+version: 0.0.11
 description: A Friendly Kubernetes CloudShell (Web Terminal)
 url: https://github.com/cloudtty/cloudtty
 
 deployTo:
   controlPlane: true
   runtimeCluster: false
-
-dependencies:
-- name: fluxcd
 
 tags:
   - Official

--- a/addons/cloudshell/template.yaml
+++ b/addons/cloudshell/template.yaml
@@ -6,13 +6,15 @@ metadata:
 spec:
   components:
     - name: cloudshell-operator
-      type: helm
+      type: helmchart
       properties:
-        repoType: helm
-        url: https://cloudtty.github.io/cloudtty
-        chart: cloudtty
-        version: 0.3.0
-        upgradeCRD: true
+        chart:
+          source: cloudtty
+          repoURL: https://cloudtty.github.io/cloudtty
+          version: "0.3.0"
+        release:
+          name: cloudshell-operator
+          namespace: vela-system
         values:
           image:
             registry: docker.io


### PR DESCRIPTION
### Description of your changes

Migrates the `cloudshell` addon from the FluxCD-backed `helm` component to the native KubeVela `helmchart` component as a scoped worked example for:

Fixes #787

This keeps the existing chart, chart version, release name, release namespace, and values:

- chart source: `cloudtty`
- chart repo: `https://cloudtty.github.io/cloudtty`
- chart version: `0.3.0`
- release name: `cloudshell-operator`
- release namespace: `vela-system`

It also bumps the addon metadata version from `0.0.10` to `0.0.11` and removes the now-unused `fluxcd` dependency.

Special review notes:

- This PR intentionally changes only one addon so maintainers can validate the migration shape before broader addon changes.
- The native `helmchart` schema was checked against current KubeVela core sources/docs for `chart.source`, `repoURL`, `version`, `release`, and top-level `values`.
- `cloudtty` `0.3.0` does not ship a Helm `crds/` directory; its CRD is rendered through a normal chart template gated by the existing `installCRDs: true` default value, so I did not add `options.includeCRDs`.
- Existing live installs may still need maintainer review for Flux-to-native takeover/upgrade behavior, because native `helmchart` does not exactly replicate Flux `upgradeCRD` semantics.

### How has this code been tested?

Ran locally:

- `make check-addon-semver`
- `git diff --check`
- `rg -n "fluxcd|GitRepository|Kustomization|Bucket|OCIRepository|HelmRepository|type:\s*helm$" addons/cloudshell`

The final grep returned no residual FluxCD or exact old `type: helm` references under `addons/cloudshell`.

Not run locally:

- `vela` render/install validation
- `helm` validation
- `cue` validation
- cluster/e2e addon install validation

Those tools were not available in my local runner environment.

### Checklist

I have:

- [x] Title of the PR starts with type (e.g. `[Addon]` , `[example]` or `[Doc]`).
- [x] Updated/Added any relevant documentation and examples. Not applicable; this updates an existing addon implementation only.
- [x] New addon should be put in experimental. Not applicable; this updates an existing addon.
- [x] Update addon should modify the `version` in `metadata.yaml` to generate a new version.

#### Verified Addon promotion rules

This PR does not promote an experimental addon to verified.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the `cloudshell` addon from Flux-backed `helm` to native KubeVela `helmchart` for simpler management and no `fluxcd` dependency. Fixes #787.

**Refactors**
- Switch component to `helmchart` (chart `cloudtty`, repo `https://cloudtty.github.io/cloudtty`, version `0.3.0`).
- Set `release.name` `cloudshell-operator` and `release.namespace` `vela-system`; keep existing values.
- Remove `fluxcd` from `dependencies`; bump addon version to `0.0.11`.
- Note: CRDs are rendered by the chart (`installCRDs: true`); no `options.includeCRDs` added.

<sup>Written for commit 2db7ff7b263af85151719d4d508765e66f5c9a0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/catalog/pull/789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

