### PR TITLE
chore:  Update the vela-workflow addon version to v0.7.0

### DIFF
--- a/addons/vela-workflow/metadata.yaml
+++ b/addons/vela-workflow/metadata.yaml
@@ -1,5 +1,5 @@
 name: vela-workflow
-version: v0.6.3
+version: v0.7.0
 description: "vela-workflow provides the capability to run a standalone workflow"
 icon: "https://static.kubevela.net/images/logos/KubeVela%20-03.png"
 url: "https://github.com/kubevela/workflow"

--- a/addons/vela-workflow/parameter.cue
+++ b/addons/vela-workflow/parameter.cue
@@ -9,7 +9,7 @@ const: {
 
 parameter: {
 	image:                *"oamdev/vela-workflow" | string
-	version:              *"0.6.2" | string
+	version:              *"0.7.0" | string
 	imagePullPolicy:      *"IfNotPresent" | "Never" | "Always"
 	concurrentReconciles: *4 | int
 	kubeQPS:              *50 | int


### PR DESCRIPTION
**Description of your changes**
Changing the vela-workflow addon version to use v0.7.0 by default

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump the `vela-workflow` addon to v0.7.0 and update the default image tag to 0.7.0. Ensures new installs use the latest features and fixes.

<sup>Written for commit 3e879cbe822f33313bd406d1337c7084cebb3526. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/catalog/pull/790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

