### PR TITLE
feat: add enableCueExpVariable to gate CUE_EXPERIMENT

### DIFF
--- a/addons/vela-workflow/metadata.yaml
+++ b/addons/vela-workflow/metadata.yaml
@@ -1,5 +1,5 @@
 name: vela-workflow
-version: v0.7.0
+version: v0.7.1
 description: "vela-workflow provides the capability to run a standalone workflow"
 icon: "https://static.kubevela.net/images/logos/KubeVela%20-03.png"
 url: "https://github.com/kubevela/workflow"

--- a/addons/vela-workflow/parameter.cue
+++ b/addons/vela-workflow/parameter.cue
@@ -9,7 +9,7 @@ const: {
 
 parameter: {
 	image:                *"oamdev/vela-workflow" | string
-	version:              *"0.7.0" | string
+	version:              *"0.7.1" | string
 	imagePullPolicy:      *"IfNotPresent" | "Never" | "Always"
 	concurrentReconciles: *4 | int
 	kubeQPS:              *50 | int
@@ -27,4 +27,6 @@ parameter: {
 	maxWorkflowWaitBackoffTime:     *60 | int
 	maxWorkflowFailedBackoffTime:   *300 | int
 	maxWorkflowStepErrorRetryTimes: *10 | int
+	// +usage=Inject the CUE_EXPERIMENT env var (evalv3=0,keepvalidators=0) into the controller to disable experimental CUE features during the v0.14.x migration window
+	enableCueExpVariable: *true | bool
 }

--- a/addons/vela-workflow/resources/vela-workflow.cue
+++ b/addons/vela-workflow/resources/vela-workflow.cue
@@ -55,6 +55,12 @@ workflow: {
 							"image":           "\(parameter.image):v\(parameter.version)"
 							"imagePullPolicy": parameter.imagePullPolicy
 							"name":            const.name
+							if parameter.enableCueExpVariable {
+								"env": [{
+									"name":  "CUE_EXPERIMENT"
+									"value": "evalv3=0,keepvalidators=0"
+								}]
+							}
 							"resources": {
 								"limits": {
 									"cpu":    parameter.resources.limits.cpu


### PR DESCRIPTION

Add an `enableCueExpVariable` parameter (default true) to the vela-workflow addon. When enabled, inject `CUE_EXPERIMENT=evalv3=0,keepvalidators=0` into the controller deployment to disable the experimental CUE features (evalv3, keepvalidators) that break existing definitions during the CUE v0.14.x migration window.

Bump addon version to v0.7.1.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `enableCueExpVariable` to the `vela-workflow` addon to keep CUE v0.14.x experiments off by default by injecting `CUE_EXPERIMENT=evalv3=0,keepvalidators=0` into the controller. Bumps addon version to v0.7.1.

- **New Features**
  - New `enableCueExpVariable` parameter (default true) to gate the `CUE_EXPERIMENT` env var.
  - When enabled, the controller Deployment gets `CUE_EXPERIMENT=evalv3=0,keepvalidators=0`; set to false to allow experiments.

<sup>Written for commit ee08b6208d5e84d50e7b3678160732cd049c6890. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/catalog/pull/791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

