### PR TITLE
chore: Update the vela-workflow addon version to v0.7.2

### DIFF
--- a/addons/vela-workflow/metadata.yaml
+++ b/addons/vela-workflow/metadata.yaml
@@ -1,5 +1,5 @@
 name: vela-workflow
-version: v0.7.1
+version: v0.7.2
 description: "vela-workflow provides the capability to run a standalone workflow"
 icon: "https://static.kubevela.net/images/logos/KubeVela%20-03.png"
 url: "https://github.com/kubevela/workflow"

--- a/addons/vela-workflow/parameter.cue
+++ b/addons/vela-workflow/parameter.cue
@@ -9,7 +9,7 @@ const: {
 
 parameter: {
 	image:                *"oamdev/vela-workflow" | string
-	version:              *"0.7.1" | string
+	version:              *"0.7.2" | string
 	imagePullPolicy:      *"IfNotPresent" | "Never" | "Always"
 	concurrentReconciles: *4 | int
 	kubeQPS:              *50 | int


### PR DESCRIPTION
**Description of your changes**
Changing the vela-workflow addon version to use v0.7.2 by default.

Bumps the `vela-workflow` addon from v0.7.1 to v0.7.2 and updates the default image tag to 0.7.2. Ensures new installs use the latest features and fixes.

Follows the same change pattern as #790.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `vela-workflow` addon to v0.7.2 and set the default image version to 0.7.2. New installs now use the latest fixes and features with no behavior changes.

<sup>Written for commit 8c22d4c1583b8ecd1e12c6b8df531278b7b0e317. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/catalog/pull/792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

